### PR TITLE
feat: 테스팅 용 이메일 회원가입 및 로그인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-aop'
 	implementation 'org.springdoc:springdoc-openapi-ui:1.6.15'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-aop'
+	implementation 'org.springdoc:springdoc-openapi-ui:1.6.15'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-aop'
 	implementation 'org.springdoc:springdoc-openapi-ui:1.6.15'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'io.jsonwebtoken:jjwt:0.9.1'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/thanksd/server/config/SecurityConfig.java
+++ b/src/main/java/com/thanksd/server/config/SecurityConfig.java
@@ -1,0 +1,29 @@
+package com.thanksd.server.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .cors().disable()
+                .csrf().disable()
+                .formLogin().disable()
+                .headers().frameOptions().disable();
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder(){
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/thanksd/server/config/SwaggerConfig.java
+++ b/src/main/java/com/thanksd/server/config/SwaggerConfig.java
@@ -1,0 +1,43 @@
+package com.thanksd.server.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.servers.Server;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+
+@OpenAPIDefinition(
+        servers = @Server(url = "/", description = "Default Server URL"),
+        info = @Info(
+                title = "Thanks:D 백엔드 API 명세",
+                description = "springdoc을 이용한 Swagger API 문서입니다.",
+                version = "1.0",
+                contact = @Contact(
+                        name = "springdoc 공식문서",
+                        url = "https://springdoc.org/"
+                )
+        )
+)
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .components(new Components().addSecuritySchemes("JWT", bearerAuth()));
+    }
+
+    public SecurityScheme bearerAuth() {
+        return new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .name(HttpHeaders.AUTHORIZATION);
+    }
+}

--- a/src/main/java/com/thanksd/server/controller/AuthController.java
+++ b/src/main/java/com/thanksd/server/controller/AuthController.java
@@ -1,9 +1,9 @@
 package com.thanksd.server.controller;
 
-import com.thanksd.server.dto.request.MemberSignUpRequest;
-import com.thanksd.server.dto.response.MemberSignUpResponse;
+import com.thanksd.server.dto.request.AuthLoginRequest;
 import com.thanksd.server.dto.response.Response;
-import com.thanksd.server.service.MemberService;
+import com.thanksd.server.dto.response.TokenResponse;
+import com.thanksd.server.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -14,18 +14,18 @@ import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
 
-@Tag(name = "Members", description = "회원")
+@Tag(name = "Login", description = "인증")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/members")
-public class MemberController {
+@RequestMapping("/login")
+public class AuthController {
 
-    private final MemberService memberService;
+    private final AuthService authService;
 
-    @Operation(summary = "이메일 회원가입")
+    @Operation(summary = "이메일 로그인")
     @PostMapping
-    public Response<?> signUp(@RequestBody @Valid MemberSignUpRequest request) {
-        MemberSignUpResponse response = memberService.signUp(request);
+    public Response<?> login(@RequestBody @Valid AuthLoginRequest request) {
+        TokenResponse response = authService.login(request);
         return Response.ofSuccess("OK", response);
     }
 }

--- a/src/main/java/com/thanksd/server/controller/MemberController.java
+++ b/src/main/java/com/thanksd/server/controller/MemberController.java
@@ -1,0 +1,30 @@
+package com.thanksd.server.controller;
+
+import com.thanksd.server.dto.request.MemberSignUpRequest;
+import com.thanksd.server.dto.response.MemberSignUpResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@Tag(name = "Members", description = "회원")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/members")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @Operation(summary = "이메일 회원가입")
+    @PostMapping
+    public ResponseEntity<MemberSignUpResponse> signUp(@RequestBody @Valid MemberSignUpRequest request) {
+        MemberSignUpResponse response = memberService.signUp(request);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/thanksd/server/controller/MemberController.java
+++ b/src/main/java/com/thanksd/server/controller/MemberController.java
@@ -2,6 +2,7 @@ package com.thanksd.server.controller;
 
 import com.thanksd.server.dto.request.MemberSignUpRequest;
 import com.thanksd.server.dto.response.MemberSignUpResponse;
+import com.thanksd.server.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/thanksd/server/domain/BaseTime.java
+++ b/src/main/java/com/thanksd/server/domain/BaseTime.java
@@ -1,0 +1,25 @@
+package com.thanksd.server.domain;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.sql.Timestamp;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTime {
+
+    @CreatedDate
+    @Column(name = "created_time", updatable = false)
+    private Timestamp createdTime;
+
+    @LastModifiedDate
+    @Column(name = "modified_time")
+    private Timestamp modifiedTime;
+}

--- a/src/main/java/com/thanksd/server/domain/Member.java
+++ b/src/main/java/com/thanksd/server/domain/Member.java
@@ -1,0 +1,57 @@
+package com.thanksd.server.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "member", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"email", "platform"})
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long id;
+
+    @Column(name = "email", nullable = false)
+    private String email;
+
+    @Column(name = "password")
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "platform")
+    private Platform platform;
+
+    @Column(name = "platform_id")
+    private String platformId;
+
+    public Member(String email, String password, Platform platform, String platformId) {
+        this.email = email;
+        this.password = password;
+        this.platform = platform;
+        this.platformId = platformId;
+    }
+
+    public Member(String email, String password) {
+        this(email, password, Platform.THANKSD, null);
+    }
+
+    public Member(String email, Platform platform, String platformId) {
+        this.email = email;
+        this.platform = platform;
+        this.platformId = platformId;
+    }
+
+    public void registerOAuthMember(String email, String nickname) {
+        if (email != null) {
+            this.email = email;
+        }
+    }
+}

--- a/src/main/java/com/thanksd/server/domain/Platform.java
+++ b/src/main/java/com/thanksd/server/domain/Platform.java
@@ -1,0 +1,28 @@
+package com.thanksd.server.domain;
+
+import com.thanksd.server.exception.badrequest.InvalidPlatformException;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public enum Platform {
+
+    KAKAO("kakao"),
+    GOOGLE("google"),
+    THANKSD("thanksd");
+
+    private String value;
+
+    public static Platform from(String value) {
+        return Arrays.stream(values())
+                .filter(it -> Objects.equals(it.value, value))
+                .findFirst()
+                .orElseThrow(InvalidPlatformException::new);
+    }
+}

--- a/src/main/java/com/thanksd/server/dto/request/AuthLoginRequest.java
+++ b/src/main/java/com/thanksd/server/dto/request/AuthLoginRequest.java
@@ -1,0 +1,21 @@
+
+package com.thanksd.server.dto.request;
+
+import lombok.*;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@ToString
+public class AuthLoginRequest {
+
+    @Email(message = "1004:이메일 형식이 올바르지 않습니다.")
+    @NotBlank(message = "1005:공백일 수 없습니다.")
+    private String email;
+
+    @NotBlank(message = "1005:공백일 수 없습니다.")
+    private String password;
+}

--- a/src/main/java/com/thanksd/server/dto/request/MemberSignUpRequest.java
+++ b/src/main/java/com/thanksd/server/dto/request/MemberSignUpRequest.java
@@ -1,0 +1,20 @@
+package com.thanksd.server.dto.request;
+
+import lombok.*;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@ToString
+public class MemberSignUpRequest {
+
+    @Email(message = "1006:이메일 형식이 올바르지 않습니다.")
+    @NotBlank(message = "1012:공백일 수 없습니다.")
+    private String email;
+
+    @NotBlank(message = "1012:공백일 수 없습니다.")
+    private String password;
+}

--- a/src/main/java/com/thanksd/server/dto/response/MemberSignUpResponse.java
+++ b/src/main/java/com/thanksd/server/dto/response/MemberSignUpResponse.java
@@ -1,0 +1,12 @@
+package com.thanksd.server.dto.response;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@ToString
+public class MemberSignUpResponse {
+
+    private Long id;
+}

--- a/src/main/java/com/thanksd/server/dto/response/Response.java
+++ b/src/main/java/com/thanksd/server/dto/response/Response.java
@@ -1,0 +1,17 @@
+package com.thanksd.server.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class Response<D> {
+
+    private String code;
+    private String message;
+    private D data;
+
+    public static <D> Response<D> ofSuccess(String message, D data) {
+        return new Response<>("200", "OK", data);
+    }
+}

--- a/src/main/java/com/thanksd/server/dto/response/TokenResponse.java
+++ b/src/main/java/com/thanksd/server/dto/response/TokenResponse.java
@@ -1,0 +1,19 @@
+package com.thanksd.server.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class TokenResponse {
+    private Long memberId;
+    private String token;
+
+    public static TokenResponse from(final Long memberId, final String token) {
+        return new TokenResponse(memberId, token);
+    }
+}

--- a/src/main/java/com/thanksd/server/exception/badrequest/BlankTokenException.java
+++ b/src/main/java/com/thanksd/server/exception/badrequest/BlankTokenException.java
@@ -1,0 +1,8 @@
+package com.thanksd.server.exception.badrequest;
+
+public class BlankTokenException extends BadRequestException {
+
+    public BlankTokenException() {
+        super("토큰은 공백일 수 없습니다.", 1008);
+    }
+}

--- a/src/main/java/com/thanksd/server/exception/badrequest/DuplicateMemberException.java
+++ b/src/main/java/com/thanksd/server/exception/badrequest/DuplicateMemberException.java
@@ -1,0 +1,11 @@
+package com.thanksd.server.exception.badrequest;
+
+import lombok.Getter;
+
+@Getter
+public class DuplicateMemberException extends BadRequestException {
+
+    public DuplicateMemberException() {
+        super("이미 존재하는 회원입니다.", 1000);
+    }
+}

--- a/src/main/java/com/thanksd/server/exception/badrequest/InvalidEmailException.java
+++ b/src/main/java/com/thanksd/server/exception/badrequest/InvalidEmailException.java
@@ -1,0 +1,8 @@
+package com.thanksd.server.exception.badrequest;
+
+public class InvalidEmailException extends BadRequestException {
+
+    public InvalidEmailException() {
+        super("이메일 형식이 올바르지 않습니다.", 1006);
+    }
+}

--- a/src/main/java/com/thanksd/server/exception/badrequest/InvalidPasswordException.java
+++ b/src/main/java/com/thanksd/server/exception/badrequest/InvalidPasswordException.java
@@ -1,0 +1,8 @@
+package com.thanksd.server.exception.badrequest;
+
+public class InvalidPasswordException extends BadRequestException {
+
+    public InvalidPasswordException() {
+        super("비밀번호는 소문자, 숫자를 모두 포함하는 8~20자로 구성되어야 합니다.", 1007);
+    }
+}

--- a/src/main/java/com/thanksd/server/exception/badrequest/InvalidPlatformException.java
+++ b/src/main/java/com/thanksd/server/exception/badrequest/InvalidPlatformException.java
@@ -1,0 +1,8 @@
+package com.thanksd.server.exception.badrequest;
+
+public class InvalidPlatformException extends BadRequestException {
+
+    public InvalidPlatformException() {
+        super("플랫폼 정보가 올바르지 않습니다.", 1010);
+    }
+}

--- a/src/main/java/com/thanksd/server/exception/badrequest/PasswordMismatchException.java
+++ b/src/main/java/com/thanksd/server/exception/badrequest/PasswordMismatchException.java
@@ -1,0 +1,8 @@
+package com.thanksd.server.exception.badrequest;
+
+public class PasswordMismatchException extends BadRequestException {
+
+    public PasswordMismatchException() {
+        super("비밀번호가 올바르지 않습니다.", 1006);
+    }
+}

--- a/src/main/java/com/thanksd/server/exception/notfound/NotFoundMemberException.java
+++ b/src/main/java/com/thanksd/server/exception/notfound/NotFoundMemberException.java
@@ -1,0 +1,11 @@
+package com.thanksd.server.exception.notfound;
+
+import lombok.Getter;
+
+@Getter
+public class NotFoundMemberException extends NotFoundException {
+
+    public NotFoundMemberException() {
+        super("존재하지 않는 회원입니다.", 1007);
+    }
+}

--- a/src/main/java/com/thanksd/server/exception/unauthorized/InvalidBearerException.java
+++ b/src/main/java/com/thanksd/server/exception/unauthorized/InvalidBearerException.java
@@ -1,0 +1,8 @@
+package com.thanksd.server.exception.unauthorized;
+
+public class InvalidBearerException extends UnauthorizedException {
+
+    public InvalidBearerException() {
+        super("로그인이 필요한 서비스입니다.", 1009);
+    }
+}

--- a/src/main/java/com/thanksd/server/exception/unauthorized/InvalidTokenException.java
+++ b/src/main/java/com/thanksd/server/exception/unauthorized/InvalidTokenException.java
@@ -1,0 +1,12 @@
+package com.thanksd.server.exception.unauthorized;
+
+public class InvalidTokenException extends UnauthorizedException {
+
+    public InvalidTokenException() {
+        super("올바르지 않은 토큰입니다. 다시 로그인해주세요.", 1010);
+    }
+
+    public InvalidTokenException(String message) {
+        super(message, 1005);
+    }
+}

--- a/src/main/java/com/thanksd/server/exception/unauthorized/TokenExpiredException.java
+++ b/src/main/java/com/thanksd/server/exception/unauthorized/TokenExpiredException.java
@@ -1,0 +1,8 @@
+package com.thanksd.server.exception.unauthorized;
+
+public class TokenExpiredException extends UnauthorizedException {
+
+    public TokenExpiredException() {
+        super("로그인 인증 유효기간이 만료되었습니다. 다시 로그인 해주세요.", 1011);
+    }
+}

--- a/src/main/java/com/thanksd/server/repository/MemberRepository.java
+++ b/src/main/java/com/thanksd/server/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package com.thanksd.server.repository;
+
+import com.thanksd.server.domain.Member;
+import com.thanksd.server.domain.Platform;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Boolean existsByEmailAndPlatform(String email, Platform platform);
+}

--- a/src/main/java/com/thanksd/server/repository/MemberRepository.java
+++ b/src/main/java/com/thanksd/server/repository/MemberRepository.java
@@ -4,7 +4,11 @@ import com.thanksd.server.domain.Member;
 import com.thanksd.server.domain.Platform;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Boolean existsByEmailAndPlatform(String email, Platform platform);
+
+    Optional<Member> findByEmailAndPlatform(String email, Platform platform);
 }

--- a/src/main/java/com/thanksd/server/security/auth/AuthenticationPrincipalArgumentResolver.java
+++ b/src/main/java/com/thanksd/server/security/auth/AuthenticationPrincipalArgumentResolver.java
@@ -1,0 +1,34 @@
+package com.thanksd.server.security.auth;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import javax.servlet.http.HttpServletRequest;
+
+@Component
+public class AuthenticationPrincipalArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public AuthenticationPrincipalArgumentResolver(final JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(LoginUserId.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        String token = AuthorizationExtractor.extractAccessToken(request);
+        String payload = jwtTokenProvider.getPayload(token);
+        return Long.parseLong(payload);
+    }
+}

--- a/src/main/java/com/thanksd/server/security/auth/AuthorizationExtractor.java
+++ b/src/main/java/com/thanksd/server/security/auth/AuthorizationExtractor.java
@@ -1,0 +1,35 @@
+package com.thanksd.server.security.auth;
+
+import com.thanksd.server.exception.badrequest.BlankTokenException;
+import com.thanksd.server.exception.unauthorized.InvalidBearerException;
+import lombok.NoArgsConstructor;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Enumeration;
+
+@NoArgsConstructor
+public class AuthorizationExtractor {
+
+    private static final String AUTHENTICATION_TYPE = "Bearer";
+    private static final String AUTHORIZATION_HEADER_KEY = "Authorization";
+    private static final int START_TOKEN_INDEX = 6;
+
+    public static String extractAccessToken(HttpServletRequest request) {
+        Enumeration<String> headers = request.getHeaders(AUTHORIZATION_HEADER_KEY);
+        while (headers.hasMoreElements()) {
+            String value = headers.nextElement();
+            if (value.toLowerCase().startsWith(AUTHENTICATION_TYPE.toLowerCase())) {
+                String extractToken = value.trim().substring(START_TOKEN_INDEX);
+                validateExtractToken(extractToken);
+                return extractToken;
+            }
+        }
+        throw new InvalidBearerException();
+    }
+
+    private static void validateExtractToken(String extractToken) {
+        if (extractToken.isBlank()) {
+            throw new BlankTokenException();
+        }
+    }
+}

--- a/src/main/java/com/thanksd/server/security/auth/JwtTokenProvider.java
+++ b/src/main/java/com/thanksd/server/security/auth/JwtTokenProvider.java
@@ -1,0 +1,55 @@
+package com.thanksd.server.security.auth;
+
+import com.thanksd.server.exception.unauthorized.InvalidTokenException;
+import com.thanksd.server.exception.unauthorized.TokenExpiredException;
+import io.jsonwebtoken.*;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider {
+    private final String secretKey;
+    private final long validityInMilliseconds;
+    private final JwtParser jwtParser;
+
+    public JwtTokenProvider(@Value("${security.jwt.token.secret-key}") String secretKey,
+                            @Value("${security.jwt.token.expire-length}") long validityInMilliseconds) {
+        this.secretKey = secretKey;
+        this.validityInMilliseconds = validityInMilliseconds;
+        this.jwtParser = Jwts.parser().setSigningKey(secretKey);
+    }
+
+    public String createToken(Long memberId) {
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + validityInMilliseconds);
+
+        return Jwts.builder()
+                .setSubject(String.valueOf(memberId))
+                .setIssuedAt(now)
+                .setExpiration(validity)
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+    }
+
+    public void validateToken(String token) {
+        try {
+            jwtParser.parseClaimsJws(token);
+        } catch (ExpiredJwtException e) {
+            throw new TokenExpiredException();
+        } catch (JwtException e) {
+            throw new InvalidTokenException();
+        }
+    }
+
+    public String getPayload(String token) {
+        try {
+            return jwtParser.parseClaimsJws(token).getBody().getSubject();
+        } catch (ExpiredJwtException e) {
+            throw new TokenExpiredException();
+        } catch (JwtException e) {
+            throw new InvalidTokenException();
+        }
+    }
+}

--- a/src/main/java/com/thanksd/server/security/auth/LoginInterceptor.java
+++ b/src/main/java/com/thanksd/server/security/auth/LoginInterceptor.java
@@ -1,0 +1,37 @@
+package com.thanksd.server.security.auth;
+
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Component
+public class LoginInterceptor implements HandlerInterceptor {
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public LoginInterceptor(final JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        if (isPreflight(request) || isSwaggerRequest(request)) {
+            return true;
+        }
+
+        String token = AuthorizationExtractor.extractAccessToken(request);
+        jwtTokenProvider.validateToken(token);
+        return true;
+    }
+
+    private boolean isSwaggerRequest(HttpServletRequest request) {
+        String uri = request.getRequestURI();
+        return uri.contains("swagger") || uri.contains("api-docs") || uri.contains("webjars");
+    }
+
+    private boolean isPreflight(HttpServletRequest request) {
+        return request.getMethod().equals(HttpMethod.OPTIONS.toString());
+    }
+}

--- a/src/main/java/com/thanksd/server/security/auth/LoginUserId.java
+++ b/src/main/java/com/thanksd/server/security/auth/LoginUserId.java
@@ -1,0 +1,15 @@
+package com.thanksd.server.security.auth;
+
+import io.swagger.v3.oas.annotations.Hidden;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Hidden
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginUserId {
+}
+

--- a/src/main/java/com/thanksd/server/service/AuthService.java
+++ b/src/main/java/com/thanksd/server/service/AuthService.java
@@ -1,9 +1,41 @@
 package com.thanksd.server.service;
 
+import com.thanksd.server.domain.Member;
+import com.thanksd.server.domain.Platform;
+import com.thanksd.server.dto.request.AuthLoginRequest;
+import com.thanksd.server.dto.response.TokenResponse;
+import com.thanksd.server.exception.badrequest.PasswordMismatchException;
+import com.thanksd.server.exception.notfound.NotFoundMemberException;
+import com.thanksd.server.repository.MemberRepository;
+import com.thanksd.server.security.auth.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class AuthService {
+
+    private final MemberRepository memberRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final PasswordEncoder passwordEncoder;
+
+    public TokenResponse login(AuthLoginRequest request) {
+        Member findMember = memberRepository.findByEmailAndPlatform(request.getEmail(), Platform.THANKSD)
+                .orElseThrow(NotFoundMemberException::new);
+        validatePassword(findMember, request.getPassword());
+
+        String token = issueToken(findMember);
+        return TokenResponse.from(findMember.getId(), token);
+    }
+
+    private String issueToken(final Member findMember) {
+        return jwtTokenProvider.createToken(findMember.getId());
+    }
+
+    private void validatePassword(final Member findMember, final String password) {
+        if (!passwordEncoder.matches(password, findMember.getPassword())) {
+            throw new PasswordMismatchException();
+        }
+    }
 }

--- a/src/main/java/com/thanksd/server/service/AuthService.java
+++ b/src/main/java/com/thanksd/server/service/AuthService.java
@@ -1,0 +1,9 @@
+package com.thanksd.server.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+}

--- a/src/main/java/com/thanksd/server/service/MemberService.java
+++ b/src/main/java/com/thanksd/server/service/MemberService.java
@@ -1,0 +1,51 @@
+package com.thanksd.server.service;
+
+import com.thanksd.server.domain.Member;
+import com.thanksd.server.domain.Platform;
+import com.thanksd.server.dto.request.MemberSignUpRequest;
+import com.thanksd.server.dto.response.MemberSignUpResponse;
+import com.thanksd.server.exception.badrequest.DuplicateMemberException;
+import com.thanksd.server.exception.badrequest.InvalidEmailException;
+import com.thanksd.server.exception.badrequest.InvalidPasswordException;
+import com.thanksd.server.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.regex.Pattern;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private static final Pattern PASSWORD_REGEX = Pattern.compile("^(?=.*[a-z])(?=.*\\d)[a-z\\d]{8,20}$");
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public MemberSignUpResponse signUp(MemberSignUpRequest request) {
+        validatePassword(request.getPassword());
+        validateDuplicateMember(request);
+
+        String encodedPassword = passwordEncoder.encode(request.getPassword());
+        try {
+            Member member = new Member(request.getEmail(), encodedPassword);
+            return new MemberSignUpResponse(memberRepository.save(member).getId());
+        } catch (DataIntegrityViolationException e) {
+            throw new DuplicateMemberException();
+        }
+    }
+
+    private void validateDuplicateMember(MemberSignUpRequest memberSignUpRequest) {
+        if (memberRepository.existsByEmailAndPlatform(memberSignUpRequest.getEmail(), Platform.THANKSD)) {
+            throw new DuplicateMemberException();
+        }
+    }
+
+    private void validatePassword(String password) {
+        if (!PASSWORD_REGEX.matcher(password).matches()) {
+            throw new InvalidPasswordException();
+        }
+    }
+}

--- a/src/main/java/com/thanksd/server/service/MemberService.java
+++ b/src/main/java/com/thanksd/server/service/MemberService.java
@@ -5,7 +5,6 @@ import com.thanksd.server.domain.Platform;
 import com.thanksd.server.dto.request.MemberSignUpRequest;
 import com.thanksd.server.dto.response.MemberSignUpResponse;
 import com.thanksd.server.exception.badrequest.DuplicateMemberException;
-import com.thanksd.server.exception.badrequest.InvalidEmailException;
 import com.thanksd.server.exception.badrequest.InvalidPasswordException;
 import com.thanksd.server.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,6 +24,10 @@ spring:
       settings:
         web-allow-others: true
 
+security.jwt.token:
+  secret-key: testtesttesttesttesttesttesttesttestttttest
+  expire-length: 1800000
+
 springdoc:
   default-consumes-media-type: application/json
   default-produces-media-type: application/json

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,3 +23,13 @@ spring:
       enabled: true
       settings:
         web-allow-others: true
+
+springdoc:
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json
+  swagger-ui:
+    path: /swagger-ui.html
+    disable-swagger-default-url: true
+    display-request-duration: true
+    operations-sorter: alpha
+    tags-sorter: alpha

--- a/src/test/java/com/thanksd/server/AuthServiceTest.java
+++ b/src/test/java/com/thanksd/server/AuthServiceTest.java
@@ -1,0 +1,57 @@
+package com.thanksd.server;
+
+import com.thanksd.server.domain.Member;
+import com.thanksd.server.domain.Platform;
+import com.thanksd.server.dto.request.AuthLoginRequest;
+import com.thanksd.server.dto.response.TokenResponse;
+import com.thanksd.server.exception.badrequest.PasswordMismatchException;
+import com.thanksd.server.repository.MemberRepository;
+import com.thanksd.server.service.AuthService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ServiceTest
+public class AuthServiceTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+    @Autowired
+    private AuthService authService;
+
+    @DisplayName("회원 로그인 요청이 옳다면 토큰을 발급한다")
+    @Test
+    void login() {
+        String email = "dlawotn3@naver.com";
+        String password = "hihi123";
+        String encodedPassword = passwordEncoder.encode(password);
+        Member member = new Member("dlawotn3@naver.com", encodedPassword, Platform.THANKSD, null);
+        memberRepository.save(member);
+        AuthLoginRequest loginRequest = new AuthLoginRequest(email, password);
+
+        TokenResponse tokenResponse = authService.login(loginRequest);
+
+        assertNotNull(tokenResponse.getToken());
+    }
+
+    @DisplayName("회원 로그인 요청이 올바르지 않다면 예외가 발생한다")
+    @Test
+    void loginWithException() {
+        String email = "dlawotn3@naver.com";
+        String password = "hihi123";
+        String encodedPassword = passwordEncoder.encode(password);
+        Member member = new Member("dlawotn3@naver.com", encodedPassword, Platform.THANKSD, null);
+        memberRepository.save(member);
+
+        AuthLoginRequest loginRequest = new AuthLoginRequest(email, "wrongPassword");
+
+        assertThrows(PasswordMismatchException.class,
+                () -> authService.login(loginRequest));
+    }
+}

--- a/src/test/java/com/thanksd/server/MemberServiceTest.java
+++ b/src/test/java/com/thanksd/server/MemberServiceTest.java
@@ -42,7 +42,7 @@ public class MemberServiceTest {
     @Test
     @DisplayName("이미 가입된 이메일이 존재하면 회원 가입 시에 예외를 반환한다")
     void signUpByDuplicateEmailMember() {
-        String email = "kth990303@naver.com";
+        String email = "dlawotn3@naver.com";
         memberRepository.save(new Member(email, Platform.THANKSD, "1111"));
         MemberSignUpRequest request = new MemberSignUpRequest(email, "a1b2c3d4");
 

--- a/src/test/java/com/thanksd/server/MemberServiceTest.java
+++ b/src/test/java/com/thanksd/server/MemberServiceTest.java
@@ -1,0 +1,52 @@
+package com.thanksd.server;
+
+import com.thanksd.server.domain.Member;
+import com.thanksd.server.domain.Platform;
+import com.thanksd.server.dto.request.MemberSignUpRequest;
+import com.thanksd.server.exception.badrequest.DuplicateMemberException;
+import com.thanksd.server.repository.MemberRepository;
+import com.thanksd.server.service.MemberService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@ServiceTest
+public class MemberServiceTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private MemberService memberService;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Test
+    @DisplayName("회원을 정상적으로 가입한다")
+    void signUp() {
+        String expected = "dlawotn3@naver.com";
+        MemberSignUpRequest request = new MemberSignUpRequest(expected, "a1b2c3d4");
+
+        memberService.signUp(request);
+
+        List<Member> actual = memberRepository.findAll();
+        assertThat(actual).hasSize(1);
+        assertThat(actual.get(0).getEmail()).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("이미 가입된 이메일이 존재하면 회원 가입 시에 예외를 반환한다")
+    void signUpByDuplicateEmailMember() {
+        String email = "kth990303@naver.com";
+        memberRepository.save(new Member(email, Platform.THANKSD, "1111"));
+        MemberSignUpRequest request = new MemberSignUpRequest(email, "a1b2c3d4");
+
+        assertThatThrownBy(() -> memberService.signUp(request))
+                .isInstanceOf(DuplicateMemberException.class);
+    }
+}

--- a/src/test/java/com/thanksd/server/MemberServiceTest.java
+++ b/src/test/java/com/thanksd/server/MemberServiceTest.java
@@ -9,7 +9,6 @@ import com.thanksd.server.service.MemberService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.List;
 
@@ -23,8 +22,6 @@ public class MemberServiceTest {
     private MemberRepository memberRepository;
     @Autowired
     private MemberService memberService;
-    @Autowired
-    private PasswordEncoder passwordEncoder;
 
     @Test
     @DisplayName("회원을 정상적으로 가입한다")

--- a/src/test/java/com/thanksd/server/ServiceTest.java
+++ b/src/test/java/com/thanksd/server/ServiceTest.java
@@ -1,0 +1,18 @@
+package com.thanksd.server;
+
+import com.thanksd.server.support.DatabaseCleanerCallback;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ExtendWith(DatabaseCleanerCallback.class)
+public @interface ServiceTest {
+}

--- a/src/test/java/com/thanksd/server/support/DatabaseCleaner.java
+++ b/src/test/java/com/thanksd/server/support/DatabaseCleaner.java
@@ -1,0 +1,50 @@
+package com.thanksd.server.support;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.annotation.PostConstruct;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.Table;
+import javax.persistence.metamodel.Type;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class DatabaseCleaner {
+
+    private static final String FOREIGN_KEY_RULE_UPDATE_FORMAT = "SET REFERENTIAL_INTEGRITY %s";
+    private static final String TRUNCATE_FORMAT = "TRUNCATE TABLE %s";
+    private static final String ID_RESET_FORMAT = "ALTER TABLE %s ALTER COLUMN %s_id RESTART WITH 1";
+
+    @PersistenceContext
+    EntityManager entityManager;
+
+    private List<String> tableNames;
+
+    @PostConstruct
+    public void findTableNames() {
+        this.tableNames = entityManager.getMetamodel()
+                .getEntities()
+                .stream()
+                .map(Type::getJavaType)
+                .map(javaType -> javaType.getAnnotation(Table.class))
+                .map(Table::name)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void execute() {
+        /* DB Truncate */
+        entityManager.flush();
+        entityManager.createNativeQuery(String.format(FOREIGN_KEY_RULE_UPDATE_FORMAT, "FALSE"))
+                .executeUpdate();
+        for (final String tableName : tableNames) {
+            entityManager.createNativeQuery(String.format(TRUNCATE_FORMAT, tableName)).executeUpdate();
+            entityManager.createNativeQuery(String.format(ID_RESET_FORMAT, tableName, tableName)).executeUpdate();
+        }
+        entityManager.createNativeQuery(String.format(FOREIGN_KEY_RULE_UPDATE_FORMAT, "TRUE"))
+                .executeUpdate();
+    }
+}

--- a/src/test/java/com/thanksd/server/support/DatabaseCleanerCallback.java
+++ b/src/test/java/com/thanksd/server/support/DatabaseCleanerCallback.java
@@ -1,0 +1,15 @@
+package com.thanksd.server.support;
+
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+public class DatabaseCleanerCallback implements BeforeEachCallback {
+
+    @Override
+    public void beforeEach(ExtensionContext context) {
+        SpringExtension.getApplicationContext(context)
+                .getBean(DatabaseCleaner.class)
+                .execute();
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,20 @@
+spring:
+  datasource:
+    url: jdbc:h2:~/konkuk;MODE=MYSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;
+    username: sa
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    open-in-view: false
+    properties:
+      hibernate:
+        create_empty_composites:
+          enabled: true
+        show_sql: true
+        format_sql: true
+        default_batch_fetch_size: 100
+  h2:
+    console:
+      enabled: true
+      settings:
+        web-allow-others: true

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -18,3 +18,7 @@ spring:
       enabled: true
       settings:
         web-allow-others: true
+
+security.jwt.token:
+  secret-key: testtesttesttesttesttesttesttesttesttesttest
+  expire-length: 864000


### PR DESCRIPTION
## 개요
- 해당 서비스는 사용자에게 OAuth 로그인만 제공하지만 편리한 테스트를 위해 이메일 로그인 기능을 추가했습니다.

## 작업사항
- swagger api docs 추가
- 이메일 회원가입 로직 추가
- 이메일 로그인 로직 추가
- 테스트 환경 구축
- 이메일 회원가입 및 로그인 관련 테스트 코드 추가

## 주의사항
- 해당 PR은 바로 머지하겠습니다.
- 사용자 인증은 아래 사진과 같이 ArgumentResolver를 이용해서 컨트롤러 단에서 `@LoginUserId` 를 붙이면 인증되도록 구현했습니다.
  - 다이어리 관련 기능은 로그인이 된 사용자만 사용할 수 있으니 아래와 같이  `@LoginUserId` 붙이시면 자동 인증처리를 수행합니다.
  - <img width="729" alt="스크린샷 2023-10-24 오후 3 59 05" src="https://github.com/Konkuk-ThanksD/Server/assets/69844138/de176039-527d-4a76-9738-845d440adc03">

- 아직 rds를 구축하지 않았고 개발 초기 단계라 **h2 - create drop** 옵션을 사용했는데 옵션 update로 바꾸고 싶다면 알려주세요.
- api docs를 생성하는 게 프론트 분들에게 좋을 거 같아 임시로 swagger로 선택했습니다. 혹시 다른 api docs로 바꾸고 싶다면 알려주세요.
  - 서버 실행 후, http://localhost:8080/swagger-ui/index.html
- 테스트를 병렬적으로 실행하기 위해 DatabaseCleaner를 생성해서 truncate하도록 테스트 환경 구축했습니다.