### PR TITLE
feat: Kakao OAuth 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-ui:1.6.15'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
+	implementation "org.springframework.cloud:spring-cloud-starter-openfeign"
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
 	implementation "org.springframework.cloud:spring-cloud-starter-openfeign"
+	implementation platform("org.springframework.cloud:spring-cloud-dependencies:2021.0.5")
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/thanksd/server/config/FeignClientConfig.java
+++ b/src/main/java/com/thanksd/server/config/FeignClientConfig.java
@@ -1,0 +1,10 @@
+package com.thanksd.server.config;
+
+import com.thanksd.server.ServerApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableFeignClients(basePackageClasses = ServerApplication.class)
+public class FeignClientConfig {
+}

--- a/src/main/java/com/thanksd/server/controller/AuthController.java
+++ b/src/main/java/com/thanksd/server/controller/AuthController.java
@@ -9,7 +9,6 @@ import com.thanksd.server.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -34,8 +33,8 @@ public class AuthController {
 
     @Operation(summary = "카카오 OAuth 로그인")
     @PostMapping("/kakao")
-    public ResponseEntity<?> loginKakao(@RequestBody @Valid KakaoLoginRequest request) {
+    public Response<?> loginKakao(@RequestBody @Valid KakaoLoginRequest request) {
         OAuthTokenResponse response = authService.kakaoOAuthLogin(request);
-        return Response.ofSuccess("OK", response)
+        return Response.ofSuccess("OK", response);
     }
 }

--- a/src/main/java/com/thanksd/server/controller/AuthController.java
+++ b/src/main/java/com/thanksd/server/controller/AuthController.java
@@ -1,12 +1,15 @@
 package com.thanksd.server.controller;
 
 import com.thanksd.server.dto.request.AuthLoginRequest;
+import com.thanksd.server.dto.request.KakaoLoginRequest;
+import com.thanksd.server.dto.response.OAuthTokenResponse;
 import com.thanksd.server.dto.response.Response;
 import com.thanksd.server.dto.response.TokenResponse;
 import com.thanksd.server.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,5 +30,12 @@ public class AuthController {
     public Response<?> login(@RequestBody @Valid AuthLoginRequest request) {
         TokenResponse response = authService.login(request);
         return Response.ofSuccess("OK", response);
+    }
+
+    @Operation(summary = "카카오 OAuth 로그인")
+    @PostMapping("/kakao")
+    public ResponseEntity<?> loginKakao(@RequestBody @Valid KakaoLoginRequest request) {
+        OAuthTokenResponse response = authService.kakaoOAuthLogin(request);
+        return Response.ofSuccess("OK", response)
     }
 }

--- a/src/main/java/com/thanksd/server/controller/MemberController.java
+++ b/src/main/java/com/thanksd/server/controller/MemberController.java
@@ -1,7 +1,9 @@
 package com.thanksd.server.controller;
 
 import com.thanksd.server.dto.request.MemberSignUpRequest;
+import com.thanksd.server.dto.request.OAuthMemberSignUpRequest;
 import com.thanksd.server.dto.response.MemberSignUpResponse;
+import com.thanksd.server.dto.response.OAuthMemberSignUpResponse;
 import com.thanksd.server.dto.response.Response;
 import com.thanksd.server.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -26,6 +28,13 @@ public class MemberController {
     @PostMapping
     public Response<?> signUp(@RequestBody @Valid MemberSignUpRequest request) {
         MemberSignUpResponse response = memberService.signUp(request);
+        return Response.ofSuccess("OK", response);
+    }
+
+    @Operation(summary = "OAuth 회원가입")
+    @PostMapping("/oauth")
+    public Response<Object> signUp(@RequestBody @Valid OAuthMemberSignUpRequest request) {
+        OAuthMemberSignUpResponse response = memberService.signUpByOAuthMember(request);
         return Response.ofSuccess("OK", response);
     }
 }

--- a/src/main/java/com/thanksd/server/domain/Member.java
+++ b/src/main/java/com/thanksd/server/domain/Member.java
@@ -49,7 +49,7 @@ public class Member extends BaseTime {
         this.platformId = platformId;
     }
 
-    public void registerOAuthMember(String email, String nickname) {
+    public void registerOAuthMember(String email) {
         if (email != null) {
             this.email = email;
         }

--- a/src/main/java/com/thanksd/server/dto/request/KakaoLoginRequest.java
+++ b/src/main/java/com/thanksd/server/dto/request/KakaoLoginRequest.java
@@ -1,0 +1,17 @@
+package com.thanksd.server.dto.request;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class KakaoLoginRequest {
+
+    @NotBlank(message = "1012:공백일 수 없습니다.")
+    private String token;
+}

--- a/src/main/java/com/thanksd/server/dto/request/KakaoLoginRequest.java
+++ b/src/main/java/com/thanksd/server/dto/request/KakaoLoginRequest.java
@@ -12,6 +12,6 @@ import javax.validation.constraints.NotBlank;
 @Getter
 public class KakaoLoginRequest {
 
-    @NotBlank(message = "1012:공백일 수 없습니다.")
+    @NotBlank(message = "1005:공백일 수 없습니다.")
     private String token;
 }

--- a/src/main/java/com/thanksd/server/dto/request/MemberSignUpRequest.java
+++ b/src/main/java/com/thanksd/server/dto/request/MemberSignUpRequest.java
@@ -11,10 +11,10 @@ import javax.validation.constraints.NotBlank;
 @ToString
 public class MemberSignUpRequest {
 
-    @Email(message = "1006:이메일 형식이 올바르지 않습니다.")
-    @NotBlank(message = "1012:공백일 수 없습니다.")
+    @Email(message = "1004:이메일 형식이 올바르지 않습니다.")
+    @NotBlank(message = "1005:공백일 수 없습니다.")
     private String email;
 
-    @NotBlank(message = "1012:공백일 수 없습니다.")
+    @NotBlank(message = "1005:공백일 수 없습니다.")
     private String password;
 }

--- a/src/main/java/com/thanksd/server/dto/request/OAuthMemberSignUpRequest.java
+++ b/src/main/java/com/thanksd/server/dto/request/OAuthMemberSignUpRequest.java
@@ -1,0 +1,20 @@
+package com.thanksd.server.dto.request;
+
+import lombok.*;
+
+import javax.validation.constraints.NotBlank;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@ToString
+public class OAuthMemberSignUpRequest {
+
+    private String email;
+
+    @NotBlank(message = "1005:공백일 수 없습니다.")
+    private String platform;
+
+    @NotBlank(message = "1005:공백일 수 없습니다.")
+    private String platformId;
+}

--- a/src/main/java/com/thanksd/server/dto/response/OAuthMemberSignUpResponse.java
+++ b/src/main/java/com/thanksd/server/dto/response/OAuthMemberSignUpResponse.java
@@ -1,0 +1,12 @@
+package com.thanksd.server.dto.response;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@ToString
+public class OAuthMemberSignUpResponse {
+
+    private Long id;
+}

--- a/src/main/java/com/thanksd/server/dto/response/OAuthTokenResponse.java
+++ b/src/main/java/com/thanksd/server/dto/response/OAuthTokenResponse.java
@@ -1,0 +1,16 @@
+package com.thanksd.server.dto.response;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@ToString
+public class OAuthTokenResponse {
+
+    private Long memberId;
+    private String token;
+    private String email;
+    private Boolean isRegistered;
+    private String platformId;
+}

--- a/src/main/java/com/thanksd/server/exception/badrequest/InvalidEmailException.java
+++ b/src/main/java/com/thanksd/server/exception/badrequest/InvalidEmailException.java
@@ -1,8 +1,0 @@
-package com.thanksd.server.exception.badrequest;
-
-public class InvalidEmailException extends BadRequestException {
-
-    public InvalidEmailException() {
-        super("이메일 형식이 올바르지 않습니다.", 1006);
-    }
-}

--- a/src/main/java/com/thanksd/server/exception/badrequest/InvalidPlatformException.java
+++ b/src/main/java/com/thanksd/server/exception/badrequest/InvalidPlatformException.java
@@ -3,6 +3,6 @@ package com.thanksd.server.exception.badrequest;
 public class InvalidPlatformException extends BadRequestException {
 
     public InvalidPlatformException() {
-        super("플랫폼 정보가 올바르지 않습니다.", 1010);
+        super("플랫폼 정보가 올바르지 않습니다.", 1003);
     }
 }

--- a/src/main/java/com/thanksd/server/exception/badrequest/PasswordMismatchException.java
+++ b/src/main/java/com/thanksd/server/exception/badrequest/PasswordMismatchException.java
@@ -3,6 +3,6 @@ package com.thanksd.server.exception.badrequest;
 public class PasswordMismatchException extends BadRequestException {
 
     public PasswordMismatchException() {
-        super("비밀번호가 올바르지 않습니다.", 1006);
+        super("비밀번호가 올바르지 않습니다.", 1002);
     }
 }

--- a/src/main/java/com/thanksd/server/exception/unauthorized/InvalidKakaoTokenException.java
+++ b/src/main/java/com/thanksd/server/exception/unauthorized/InvalidKakaoTokenException.java
@@ -3,6 +3,6 @@ package com.thanksd.server.exception.unauthorized;
 public class InvalidKakaoTokenException extends UnauthorizedException {
 
     public InvalidKakaoTokenException() {
-        super("올바르지 않은 카카오 토큰입니다.", 1014);
+        super("올바르지 않은 카카오 토큰입니다.", 1001);
     }
 }

--- a/src/main/java/com/thanksd/server/exception/unauthorized/InvalidKakaoTokenException.java
+++ b/src/main/java/com/thanksd/server/exception/unauthorized/InvalidKakaoTokenException.java
@@ -1,0 +1,8 @@
+package com.thanksd.server.exception.unauthorized;
+
+public class InvalidKakaoTokenException extends UnauthorizedException {
+
+    public InvalidKakaoTokenException() {
+        super("올바르지 않은 카카오 토큰입니다.", 1014);
+    }
+}

--- a/src/main/java/com/thanksd/server/exception/unauthorized/InvalidTokenException.java
+++ b/src/main/java/com/thanksd/server/exception/unauthorized/InvalidTokenException.java
@@ -7,6 +7,6 @@ public class InvalidTokenException extends UnauthorizedException {
     }
 
     public InvalidTokenException(String message) {
-        super(message, 1005);
+        super(message, 1010);
     }
 }

--- a/src/main/java/com/thanksd/server/exception/unauthorized/TokenExpiredException.java
+++ b/src/main/java/com/thanksd/server/exception/unauthorized/TokenExpiredException.java
@@ -3,6 +3,6 @@ package com.thanksd.server.exception.unauthorized;
 public class TokenExpiredException extends UnauthorizedException {
 
     public TokenExpiredException() {
-        super("로그인 인증 유효기간이 만료되었습니다. 다시 로그인 해주세요.", 1011);
+        super("로그인 인증 유효기간이 만료되었습니다. 다시 로그인 해주세요.", 1006);
     }
 }

--- a/src/main/java/com/thanksd/server/repository/MemberRepository.java
+++ b/src/main/java/com/thanksd/server/repository/MemberRepository.java
@@ -11,4 +11,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Boolean existsByEmailAndPlatform(String email, Platform platform);
 
     Optional<Member> findByEmailAndPlatform(String email, Platform platform);
+
+    Optional<Member> findByPlatformAndPlatformId(Platform platform, String platformId);
 }

--- a/src/main/java/com/thanksd/server/repository/MemberRepository.java
+++ b/src/main/java/com/thanksd/server/repository/MemberRepository.java
@@ -3,6 +3,7 @@ package com.thanksd.server.repository;
 import com.thanksd.server.domain.Member;
 import com.thanksd.server.domain.Platform;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
@@ -13,4 +14,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmailAndPlatform(String email, Platform platform);
 
     Optional<Member> findByPlatformAndPlatformId(Platform platform, String platformId);
+
+    @Query("select m.id from Member m where m.platform = :platform and m.platformId = :platformId")
+    Optional<Long> findIdByPlatformAndPlatformId(Platform platform, String platformId);
 }

--- a/src/main/java/com/thanksd/server/security/auth/OAuthPlatformMemberResponse.java
+++ b/src/main/java/com/thanksd/server/security/auth/OAuthPlatformMemberResponse.java
@@ -1,0 +1,15 @@
+package com.thanksd.server.security.auth;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class OAuthPlatformMemberResponse {
+
+    private String platformId;
+    private String email;
+}

--- a/src/main/java/com/thanksd/server/security/auth/kakao/KakaoOAuthUserProvider.java
+++ b/src/main/java/com/thanksd/server/security/auth/kakao/KakaoOAuthUserProvider.java
@@ -1,0 +1,27 @@
+package com.thanksd.server.security.auth.kakao;
+
+import com.thanksd.server.exception.unauthorized.InvalidKakaoTokenException;
+import com.thanksd.server.security.auth.OAuthPlatformMemberResponse;
+import feign.FeignException;
+import org.springframework.stereotype.Component;
+
+@Component
+public class KakaoOAuthUserProvider {
+
+    private final KakaoUserClient kakaoUserClient;
+    private static final String AUTHORIZATION_BEARER = "Bearer ";
+
+    public KakaoOAuthUserProvider(KakaoUserClient kakaoUserClient) {
+        this.kakaoUserClient = kakaoUserClient;
+    }
+
+    public OAuthPlatformMemberResponse getKakaoPlatformMember(String token) {
+        try {
+            KakaoUserRequest kakaoUserRequest = new KakaoUserRequest("[\"kakao_account.email\"]");
+            KakaoUser user = kakaoUserClient.getUser(kakaoUserRequest, AUTHORIZATION_BEARER + token);
+            return new OAuthPlatformMemberResponse(String.valueOf(user.getId()), user.getEmail());
+        } catch (FeignException e) {
+            throw new InvalidKakaoTokenException();
+        }
+    }
+}

--- a/src/main/java/com/thanksd/server/security/auth/kakao/KakaoUser.java
+++ b/src/main/java/com/thanksd/server/security/auth/kakao/KakaoUser.java
@@ -1,0 +1,29 @@
+package com.thanksd.server.security.auth.kakao;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class KakaoUser {
+
+    private Long id;
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    public String getEmail() {
+        return kakaoAccount.getEmail();
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    private static class KakaoAccount {
+
+        private String email;
+    }
+}

--- a/src/main/java/com/thanksd/server/security/auth/kakao/KakaoUserClient.java
+++ b/src/main/java/com/thanksd/server/security/auth/kakao/KakaoUserClient.java
@@ -1,0 +1,13 @@
+package com.thanksd.server.security.auth.kakao;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.cloud.openfeign.SpringQueryMap;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(name = "kakao-user-client", url = "https://kapi.kakao.com/v2/user/me")
+public interface KakaoUserClient {
+
+    @GetMapping
+    KakaoUser getUser(@SpringQueryMap KakaoUserRequest request, @RequestHeader(name = "Authorization") String token);
+}

--- a/src/main/java/com/thanksd/server/security/auth/kakao/KakaoUserRequest.java
+++ b/src/main/java/com/thanksd/server/security/auth/kakao/KakaoUserRequest.java
@@ -1,0 +1,17 @@
+package com.thanksd.server.security.auth.kakao;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class KakaoUserRequest {
+
+    private String secure_resource;
+    private String property_keys;
+
+    public KakaoUserRequest(String propertyKeys) {
+        this.secure_resource = "true";
+        this.property_keys = propertyKeys;
+    }
+}

--- a/src/main/java/com/thanksd/server/service/AuthService.java
+++ b/src/main/java/com/thanksd/server/service/AuthService.java
@@ -3,11 +3,15 @@ package com.thanksd.server.service;
 import com.thanksd.server.domain.Member;
 import com.thanksd.server.domain.Platform;
 import com.thanksd.server.dto.request.AuthLoginRequest;
+import com.thanksd.server.dto.request.KakaoLoginRequest;
+import com.thanksd.server.dto.response.OAuthTokenResponse;
 import com.thanksd.server.dto.response.TokenResponse;
 import com.thanksd.server.exception.badrequest.PasswordMismatchException;
 import com.thanksd.server.exception.notfound.NotFoundMemberException;
 import com.thanksd.server.repository.MemberRepository;
 import com.thanksd.server.security.auth.JwtTokenProvider;
+import com.thanksd.server.security.auth.OAuthPlatformMemberResponse;
+import com.thanksd.server.security.auth.kakao.KakaoOAuthUserProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -19,6 +23,7 @@ public class AuthService {
     private final MemberRepository memberRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final PasswordEncoder passwordEncoder;
+    private final KakaoOAuthUserProvider kakaoOAuthUserProvider;
 
     public TokenResponse login(AuthLoginRequest request) {
         Member findMember = memberRepository.findByEmailAndPlatform(request.getEmail(), Platform.THANKSD)
@@ -37,5 +42,31 @@ public class AuthService {
         if (!passwordEncoder.matches(password, findMember.getPassword())) {
             throw new PasswordMismatchException();
         }
+    }
+
+    public OAuthTokenResponse kakaoOAuthLogin(KakaoLoginRequest request) {
+        OAuthPlatformMemberResponse kakaoPlatformMember =
+                kakaoOAuthUserProvider.getKakaoPlatformMember(request.getToken());
+        return generateOAuthTokenResponse(
+                Platform.KAKAO,
+                kakaoPlatformMember.getEmail(),
+                kakaoPlatformMember.getPlatformId()
+        );
+    }
+
+    private OAuthTokenResponse generateOAuthTokenResponse(Platform platform, String email, String platformId) {
+        return memberRepository.findIdByPlatformAndPlatformId(platform, platformId)
+                .map(memberId -> {
+                    Member findMember = memberRepository.findById(memberId)
+                            .orElseThrow(NotFoundMemberException::new);
+                    String token = issueToken(findMember);
+                    return new OAuthTokenResponse(memberId, token, findMember.getEmail(), true, platformId);
+                })
+                .orElseGet(() -> {
+                    Member oauthMember = new Member(email, platform, platformId);
+                    Member savedMember = memberRepository.save(oauthMember);
+                    String token = issueToken(savedMember);
+                    return new OAuthTokenResponse(savedMember.getId(), token, email, false, platformId);
+                });
     }
 }

--- a/src/main/java/com/thanksd/server/service/MemberService.java
+++ b/src/main/java/com/thanksd/server/service/MemberService.java
@@ -3,14 +3,18 @@ package com.thanksd.server.service;
 import com.thanksd.server.domain.Member;
 import com.thanksd.server.domain.Platform;
 import com.thanksd.server.dto.request.MemberSignUpRequest;
+import com.thanksd.server.dto.request.OAuthMemberSignUpRequest;
 import com.thanksd.server.dto.response.MemberSignUpResponse;
+import com.thanksd.server.dto.response.OAuthMemberSignUpResponse;
 import com.thanksd.server.exception.badrequest.DuplicateMemberException;
 import com.thanksd.server.exception.badrequest.InvalidPasswordException;
+import com.thanksd.server.exception.notfound.NotFoundMemberException;
 import com.thanksd.server.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.regex.Pattern;
 
@@ -46,5 +50,15 @@ public class MemberService {
         if (!PASSWORD_REGEX.matcher(password).matches()) {
             throw new InvalidPasswordException();
         }
+    }
+
+    @Transactional
+    public OAuthMemberSignUpResponse signUpByOAuthMember(OAuthMemberSignUpRequest request) {
+        Platform platform = Platform.from(request.getPlatform());
+        Member member = memberRepository.findByPlatformAndPlatformId(platform, request.getPlatformId())
+                .orElseThrow(NotFoundMemberException::new);
+
+        member.registerOAuthMember(request.getEmail());
+        return new OAuthMemberSignUpResponse(member.getId());
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,7 +4,7 @@ spring:
     username: sa
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     open-in-view: false
     properties:
       hibernate:

--- a/src/test/java/com/thanksd/server/MemberServiceTest.java
+++ b/src/test/java/com/thanksd/server/MemberServiceTest.java
@@ -3,7 +3,9 @@ package com.thanksd.server;
 import com.thanksd.server.domain.Member;
 import com.thanksd.server.domain.Platform;
 import com.thanksd.server.dto.request.MemberSignUpRequest;
+import com.thanksd.server.dto.request.OAuthMemberSignUpRequest;
 import com.thanksd.server.exception.badrequest.DuplicateMemberException;
+import com.thanksd.server.exception.notfound.NotFoundMemberException;
 import com.thanksd.server.repository.MemberRepository;
 import com.thanksd.server.service.MemberService;
 import org.junit.jupiter.api.DisplayName;
@@ -45,5 +47,31 @@ public class MemberServiceTest {
 
         assertThatThrownBy(() -> memberService.signUp(request))
                 .isInstanceOf(DuplicateMemberException.class);
+    }
+
+    @Test
+    @DisplayName("OAuth 유저 로그인 후 정보를 입력받아 회원을 가입한다")
+    void signUpByOAuthMember() {
+        String email = "dlawotn3@naver.com";
+        String platformId = "1234321";
+        Member savedMember = memberRepository.save(new Member(email, Platform.KAKAO, platformId));
+        OAuthMemberSignUpRequest request = new OAuthMemberSignUpRequest(null, Platform.KAKAO.getValue(),
+                platformId);
+
+        memberService.signUpByOAuthMember(request);
+
+        Member actual = memberRepository.findById(savedMember.getId()).orElseThrow();
+        assertThat(actual.getEmail()).isEqualTo(email);
+    }
+
+    @Test
+    @DisplayName("OAuth 유저 로그인 후 회원가입 시 platform과 platformId 정보로 회원이 존재하지 않으면 예외를 반환한다")
+    void signUpByOAuthMemberWhenInvalidPlatformInfo() {
+        memberRepository.save(new Member("dlawotn3@naver.com", Platform.KAKAO, "1234321"));
+        OAuthMemberSignUpRequest request = new OAuthMemberSignUpRequest(null, Platform.KAKAO.getValue(),
+                "invalid");
+
+        assertThatThrownBy(() -> memberService.signUpByOAuthMember(request))
+                .isInstanceOf(NotFoundMemberException.class);
     }
 }

--- a/src/test/java/com/thanksd/server/security/auth/AuthorizationExtractorTest.java
+++ b/src/test/java/com/thanksd/server/security/auth/AuthorizationExtractorTest.java
@@ -1,0 +1,22 @@
+package com.thanksd.server.security.auth;
+
+import com.thanksd.server.exception.badrequest.BlankTokenException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AuthorizationExtractorTest {
+
+    @DisplayName("공백 값으로 access token 추출을 시도하면 예외를 반환한다")
+    @Test
+    void extractAccessTokenByBlankToken() {
+        String token = "Bearer ";
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", token);
+
+        assertThatThrownBy(() -> AuthorizationExtractor.extractAccessToken(request))
+                .isInstanceOf(BlankTokenException.class);
+    }
+}

--- a/src/test/java/com/thanksd/server/security/auth/JwtTokenProviderTest.java
+++ b/src/test/java/com/thanksd/server/security/auth/JwtTokenProviderTest.java
@@ -1,0 +1,83 @@
+package com.thanksd.server.security.auth;
+
+import com.thanksd.server.exception.unauthorized.InvalidTokenException;
+import com.thanksd.server.exception.unauthorized.TokenExpiredException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+
+@SpringBootTest
+class JwtTokenProviderTest {
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+    private String token;
+
+    @DisplayName("payload 정보를 통해 유효한 JWT 토큰을 생성한다")
+    @Test
+    public void createToken() {
+        Long payload = 1L;
+
+        String token = jwtTokenProvider.createToken(payload);
+
+        Assertions.assertNotNull(token);
+        Assertions.assertTrue(token.length() > 0);
+    }
+
+    @DisplayName("올바른 토큰 정보로 payload를 조회한다")
+    @Test
+    void getPayload() {
+        token = jwtTokenProvider.createToken(1L);
+
+        String payload = jwtTokenProvider.getPayload(token);
+
+        assertThat(jwtTokenProvider.getPayload(token)).isEqualTo(payload);
+    }
+
+    @DisplayName("유효하지 않은 토큰 형식의 토큰으로 payload를 조회할 경우 예외를 발생시킨다")
+    @Test
+    void getPayloadByInvalidToken() {
+        String invalidToken = "invalid-token";
+
+        assertThatThrownBy(() -> jwtTokenProvider.validateToken(invalidToken))
+                .isInstanceOf(InvalidTokenException.class);
+    }
+
+    @DisplayName("만료된 토큰으로 payload를 조회할 경우 예외를 발생시킨다")
+    @Test
+    void getPayloadByExpiredToken() {
+        long expirationMillis = 1L;
+        JwtTokenProvider jwtTokenProvider = new JwtTokenProvider("secret-key", expirationMillis);
+        Long expiredPayload = 1L;
+
+        String expiredToken = jwtTokenProvider.createToken(expiredPayload);
+        try {
+            Thread.sleep(expirationMillis);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        assertThatThrownBy(() -> jwtTokenProvider.getPayload(expiredToken))
+                .isInstanceOf(TokenExpiredException.class);
+    }
+
+    @DisplayName("시크릿 키가 틀린 토큰 정보로 payload를 조회할 경우 예외를 발생시킨다")
+    @Test
+    void getPayloadByWrongSecretKeyToken() {
+        Long payload = 1L;
+        String correctSecretKey = "correct-secret-key";
+        String wrongSecretKey = "wrong-secret-key";
+
+        JwtTokenProvider tokenProvider = new JwtTokenProvider(correctSecretKey, 3600000L);
+        String token = tokenProvider.createToken(payload);
+
+        assertThatExceptionOfType(InvalidTokenException.class)
+                .isThrownBy(() -> {
+                    JwtTokenProvider wrongTokenProvider = new JwtTokenProvider(wrongSecretKey, 3600000L);
+                    wrongTokenProvider.getPayload(token);
+                });
+    }
+}

--- a/src/test/java/com/thanksd/server/service/AuthServiceTest.java
+++ b/src/test/java/com/thanksd/server/service/AuthServiceTest.java
@@ -3,16 +3,25 @@ package com.thanksd.server.service;
 import com.thanksd.server.domain.Member;
 import com.thanksd.server.domain.Platform;
 import com.thanksd.server.dto.request.AuthLoginRequest;
+import com.thanksd.server.dto.request.KakaoLoginRequest;
+import com.thanksd.server.dto.response.OAuthTokenResponse;
 import com.thanksd.server.dto.response.TokenResponse;
 import com.thanksd.server.exception.badrequest.PasswordMismatchException;
 import com.thanksd.server.repository.MemberRepository;
+import com.thanksd.server.security.auth.OAuthPlatformMemberResponse;
+import com.thanksd.server.security.auth.kakao.KakaoOAuthUserProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 
 @ServiceTest
 public class AuthServiceTest {
@@ -23,6 +32,9 @@ public class AuthServiceTest {
     private PasswordEncoder passwordEncoder;
     @Autowired
     private AuthService authService;
+
+    @MockBean
+    private KakaoOAuthUserProvider kakaoOAuthUserProvider;
 
     @DisplayName("회원 로그인 요청이 옳다면 토큰을 발급한다")
     @Test
@@ -52,5 +64,43 @@ public class AuthServiceTest {
 
         assertThrows(PasswordMismatchException.class,
                 () -> authService.login(loginRequest));
+    }
+
+    @Test
+    @DisplayName("Kakao OAuth 로그인 시 가입되지 않은 회원일 경우 이메일 값을 보내고 isRegistered 값을 false로 보낸다")
+    void loginKakaoOAuthNotRegistered() {
+        String expected = "dlawotn3@kakao.com";
+        String platformId = "1234321";
+        when(kakaoOAuthUserProvider.getKakaoPlatformMember(anyString()))
+                .thenReturn(new OAuthPlatformMemberResponse(platformId, expected));
+
+        OAuthTokenResponse actual = authService.kakaoOAuthLogin(new KakaoLoginRequest("token"));
+
+        assertAll(
+                () -> assertThat(actual.getToken()).isNotNull(),
+                () -> assertThat(actual.getEmail()).isEqualTo(expected),
+                () -> assertThat(actual.getIsRegistered()).isFalse(),
+                () -> assertThat(actual.getPlatformId()).isEqualTo(platformId)
+        );
+    }
+
+    @Test
+    @DisplayName("Kakao OAuth 로그인 시 이미 가입된 회원일 경우 토큰과 이메일, 그리고 isRegistered 값을 true로 보낸다")
+    void loginKakaoOAuthRegisteredAndMocacongMember() {
+        String expected = "dlawotn3@kakao.com";
+        String platformId = "1234321";
+        Member member = new Member(expected, Platform.KAKAO, platformId);
+        memberRepository.save(member);
+        when(kakaoOAuthUserProvider.getKakaoPlatformMember(anyString()))
+                .thenReturn(new OAuthPlatformMemberResponse(platformId, expected));
+
+        OAuthTokenResponse actual = authService.kakaoOAuthLogin(new KakaoLoginRequest("token"));
+
+        assertAll(
+                () -> assertThat(actual.getToken()).isNotNull(),
+                () -> assertThat(actual.getEmail()).isEqualTo(expected),
+                () -> assertThat(actual.getIsRegistered()).isTrue(),
+                () -> assertThat(actual.getPlatformId()).isEqualTo(platformId)
+        );
     }
 }


### PR DESCRIPTION
## 개요
- 카카오 OAuth 로그인을 구현했습니다.
- 주요 로직은 다음과 같습니다.
  - <img width="400" alt="image" src="https://github.com/Konkuk-ThanksD/Server/assets/69844138/670319cc-6228-4124-a3a1-f3b8eca2d895">
  - 먼저 프론트 측이 서버에게 카카오 accessToken을 넘김
  - 카카오 OAuth로 로그인 한 적이 없는 회원 -> OAuth 회원가입 API 호출 -> 카카오 OAuth 로그인 API 호출 -> accessToken 발급
  - 카카오 OAuth로 로그인 한 적이 있는 회원 -> accessToken 발급
  - 카카오 OAuth 회원가입 여부는 `OAuthTokenResponse`의 `isRegistered` 를 통해 알 수 있습니다


## 작업사항
- FeignClient 의존성 추가
- 카카오 OAuth 로그인 로직 추가
- OAuth 회원가입 로직 추가
- 카카오 OAuth 관련 테스트 코드 추가
- OAuth 회원가입 관련 테스트 코드 추가
- 개발 임시 DB 옵션 update로 변경

## 주의사항
- 카카오 OAuth 로그인은 지금은 테스트 불가능합니다. 서버 배포 후, 프론트에서 직접 API를 호출해야 잘 작동되는 지 알 수 있어서 로직이 괜찮은지만 확인해주시면 됩니다
- 개발 임시 DB 옵션을 update로 변경했습니다. 다른 옵션으로 바꾸고 싶다면 알려주세요.
- 카카오 OAuth 로직이 괜찮은지 확인해주세요.
