### PR TITLE
feat: Member 엔티티에 Nation 컬럼 추가

### DIFF
--- a/src/main/java/com/thanksd/server/domain/Member.java
+++ b/src/main/java/com/thanksd/server/domain/Member.java
@@ -36,26 +36,29 @@ public class Member extends BaseTime {
     @Column(name = "nation")
     private Nation nation;
 
-    public Member(String email, String password, Platform platform, String platformId) {
+    public Member(String email, String password, Platform platform, String platformId, Nation nation) {
         this.email = email;
         this.password = password;
         this.platform = platform;
         this.platformId = platformId;
+        this.nation = nation;
     }
 
     public Member(String email, String password) {
-        this(email, password, Platform.THANKSD, null);
+        this(email, password, Platform.THANKSD, null, Nation.KOREA);
     }
 
-    public Member(String email, Platform platform, String platformId) {
+    public Member(String email, Platform platform, String platformId, Nation nation) {
         this.email = email;
         this.platform = platform;
         this.platformId = platformId;
+        this.nation = nation;
     }
 
-    public void registerOAuthMember(String email) {
+    public void registerOAuthMember(String email, Nation nation) {
         if (email != null) {
             this.email = email;
+            this.nation = nation;
         }
     }
 }

--- a/src/main/java/com/thanksd/server/domain/Member.java
+++ b/src/main/java/com/thanksd/server/domain/Member.java
@@ -32,6 +32,10 @@ public class Member extends BaseTime {
     @Column(name = "platform_id")
     private String platformId;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "nation")
+    private Nation nation;
+
     public Member(String email, String password, Platform platform, String platformId) {
         this.email = email;
         this.password = password;

--- a/src/main/java/com/thanksd/server/domain/Nation.java
+++ b/src/main/java/com/thanksd/server/domain/Nation.java
@@ -1,0 +1,27 @@
+package com.thanksd.server.domain;
+
+import com.thanksd.server.exception.badrequest.InvalidNationException;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public enum Nation {
+
+    KOREA("korea"),
+    NETHERLANDS("netherlands");
+
+    private String value;
+
+    public static Nation from(String value) {
+        return Arrays.stream(values())
+                .filter(it -> Objects.equals(it.value, value))
+                .findFirst()
+                .orElseThrow(InvalidNationException::new);
+    }
+}

--- a/src/main/java/com/thanksd/server/dto/request/OAuthMemberSignUpRequest.java
+++ b/src/main/java/com/thanksd/server/dto/request/OAuthMemberSignUpRequest.java
@@ -17,4 +17,7 @@ public class OAuthMemberSignUpRequest {
 
     @NotBlank(message = "1005:공백일 수 없습니다.")
     private String platformId;
+
+    @NotBlank(message = "1005:공백일 수 없습니다.")
+    private String nation;
 }

--- a/src/main/java/com/thanksd/server/exception/badrequest/InvalidNationException.java
+++ b/src/main/java/com/thanksd/server/exception/badrequest/InvalidNationException.java
@@ -1,0 +1,8 @@
+package com.thanksd.server.exception.badrequest;
+
+public class InvalidNationException extends BadRequestException {
+
+    public InvalidNationException() {
+        super("국가 정보가 올바르지 않습니다.", 1003);
+    }
+}

--- a/src/main/java/com/thanksd/server/security/auth/google/GoogleAuthProperties.java
+++ b/src/main/java/com/thanksd/server/security/auth/google/GoogleAuthProperties.java
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Configuration;
 @Getter
 @Configuration
 @ConfigurationProperties("spring.security.oauth2.client.registration.google")
-public class AuthProperties {
+public class GoogleAuthProperties {
 
     private String clientId;
     private String clientSecret;

--- a/src/main/java/com/thanksd/server/security/auth/google/GoogleOAuthUserProvider.java
+++ b/src/main/java/com/thanksd/server/security/auth/google/GoogleOAuthUserProvider.java
@@ -9,12 +9,12 @@ import org.springframework.stereotype.Component;
 public class GoogleOAuthUserProvider {
 
     private final GoogleAuthClient googleAuthClient;
-    private final AuthProperties authProperties;
+    private final GoogleAuthProperties googleAuthProperties;
     private final GoogleInfoClient googleInfoClient;
 
-    public GoogleOAuthUserProvider(GoogleAuthClient googleAuthClient, AuthProperties authProperties, GoogleInfoClient googleInfoClient) {
+    public GoogleOAuthUserProvider(GoogleAuthClient googleAuthClient, GoogleAuthProperties googleAuthProperties, GoogleInfoClient googleInfoClient) {
         this.googleAuthClient = googleAuthClient;
-        this.authProperties = authProperties;
+        this.googleAuthProperties = googleAuthProperties;
         this.googleInfoClient = googleInfoClient;
     }
 
@@ -33,9 +33,9 @@ public class GoogleOAuthUserProvider {
     public GoogleTokenRequest createRequest(String code) {
         return GoogleTokenRequest.builder()
                 .code(code)
-                .clientId(authProperties.getClientId())
-                .clientSecret(authProperties.getClientSecret())
-                .redirectUri(authProperties.getRedirectUri())
+                .clientId(googleAuthProperties.getClientId())
+                .clientSecret(googleAuthProperties.getClientSecret())
+                .redirectUri(googleAuthProperties.getRedirectUri())
                 .build();
     }
 }

--- a/src/main/java/com/thanksd/server/service/AuthService.java
+++ b/src/main/java/com/thanksd/server/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.thanksd.server.service;
 
 import com.thanksd.server.domain.Member;
+import com.thanksd.server.domain.Nation;
 import com.thanksd.server.domain.Platform;
 import com.thanksd.server.dto.request.AuthLoginRequest;
 import com.thanksd.server.dto.request.GoogleLoginRequest;
@@ -76,7 +77,7 @@ public class AuthService {
                     return new OAuthTokenResponse(memberId, token, findMember.getEmail(), true, platformId);
                 })
                 .orElseGet(() -> {
-                    Member oauthMember = new Member(email, platform, platformId);
+                    Member oauthMember = new Member(email, platform, platformId, Nation.KOREA);
                     Member savedMember = memberRepository.save(oauthMember);
                     String token = issueToken(savedMember);
                     return new OAuthTokenResponse(savedMember.getId(), token, email, false, platformId);

--- a/src/main/java/com/thanksd/server/service/MemberService.java
+++ b/src/main/java/com/thanksd/server/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.thanksd.server.service;
 
 import com.thanksd.server.domain.Member;
+import com.thanksd.server.domain.Nation;
 import com.thanksd.server.domain.Platform;
 import com.thanksd.server.dto.request.MemberSignUpRequest;
 import com.thanksd.server.dto.request.OAuthMemberSignUpRequest;
@@ -55,10 +56,11 @@ public class MemberService {
     @Transactional
     public OAuthMemberSignUpResponse signUpByOAuthMember(OAuthMemberSignUpRequest request) {
         Platform platform = Platform.from(request.getPlatform());
+        Nation nation = Nation.from(request.getNation());
         Member member = memberRepository.findByPlatformAndPlatformId(platform, request.getPlatformId())
                 .orElseThrow(NotFoundMemberException::new);
 
-        member.registerOAuthMember(request.getEmail());
+        member.registerOAuthMember(request.getEmail(), nation);
         return new OAuthMemberSignUpResponse(member.getId());
     }
 }

--- a/src/test/java/com/thanksd/server/domain/BaseTimeTest.java
+++ b/src/test/java/com/thanksd/server/domain/BaseTimeTest.java
@@ -20,7 +20,7 @@ class BaseTimeTest {
     @Test
     @DisplayName("멤버를 저장하면 생성 시각이 자동으로 저장된다")
     public void memberCreatedAtNow() {
-        Member member = new Member("dlawotn3@naver.com", Platform.KAKAO, "1111");
+        Member member = new Member("dlawotn3@naver.com", Platform.KAKAO, "1111", Nation.KOREA);
 
         memberRepository.save(member);
 

--- a/src/test/java/com/thanksd/server/service/AuthServiceTest.java
+++ b/src/test/java/com/thanksd/server/service/AuthServiceTest.java
@@ -1,6 +1,7 @@
 package com.thanksd.server.service;
 
 import com.thanksd.server.domain.Member;
+import com.thanksd.server.domain.Nation;
 import com.thanksd.server.domain.Platform;
 import com.thanksd.server.dto.request.AuthLoginRequest;
 import com.thanksd.server.dto.request.KakaoLoginRequest;
@@ -42,7 +43,8 @@ public class AuthServiceTest {
         String email = "dlawotn3@naver.com";
         String password = "hihi123";
         String encodedPassword = passwordEncoder.encode(password);
-        Member member = new Member("dlawotn3@naver.com", encodedPassword, Platform.THANKSD, null);
+        Member member = new Member("dlawotn3@naver.com", encodedPassword, Platform.THANKSD, null,
+                Nation.KOREA);
         memberRepository.save(member);
         AuthLoginRequest loginRequest = new AuthLoginRequest(email, password);
 
@@ -57,7 +59,8 @@ public class AuthServiceTest {
         String email = "dlawotn3@naver.com";
         String password = "hihi123";
         String encodedPassword = passwordEncoder.encode(password);
-        Member member = new Member("dlawotn3@naver.com", encodedPassword, Platform.THANKSD, null);
+        Member member = new Member("dlawotn3@naver.com", encodedPassword, Platform.THANKSD, null,
+                Nation.KOREA);
         memberRepository.save(member);
 
         AuthLoginRequest loginRequest = new AuthLoginRequest(email, "wrongPassword");
@@ -89,7 +92,7 @@ public class AuthServiceTest {
     void loginKakaoOAuthRegisteredAndMocacongMember() {
         String expected = "dlawotn3@kakao.com";
         String platformId = "1234321";
-        Member member = new Member(expected, Platform.KAKAO, platformId);
+        Member member = new Member(expected, Platform.KAKAO, platformId, Nation.KOREA);
         memberRepository.save(member);
         when(kakaoOAuthUserProvider.getKakaoPlatformMember(anyString()))
                 .thenReturn(new OAuthPlatformMemberResponse(platformId, expected));

--- a/src/test/java/com/thanksd/server/service/MemberServiceTest.java
+++ b/src/test/java/com/thanksd/server/service/MemberServiceTest.java
@@ -1,6 +1,7 @@
 package com.thanksd.server.service;
 
 import com.thanksd.server.domain.Member;
+import com.thanksd.server.domain.Nation;
 import com.thanksd.server.domain.Platform;
 import com.thanksd.server.dto.request.MemberSignUpRequest;
 import com.thanksd.server.dto.request.OAuthMemberSignUpRequest;
@@ -41,7 +42,7 @@ public class MemberServiceTest {
     @DisplayName("이미 가입된 이메일이 존재하면 회원 가입 시에 예외를 반환한다")
     void signUpByDuplicateEmailMember() {
         String email = "dlawotn3@naver.com";
-        memberRepository.save(new Member(email, Platform.THANKSD, "1111"));
+        memberRepository.save(new Member(email, Platform.THANKSD, "1111", Nation.KOREA));
         MemberSignUpRequest request = new MemberSignUpRequest(email, "a1b2c3d4");
 
         assertThatThrownBy(() -> memberService.signUp(request))
@@ -53,9 +54,9 @@ public class MemberServiceTest {
     void signUpByOAuthMember() {
         String email = "dlawotn3@naver.com";
         String platformId = "1234321";
-        Member savedMember = memberRepository.save(new Member(email, Platform.KAKAO, platformId));
+        Member savedMember = memberRepository.save(new Member(email, Platform.KAKAO, platformId, Nation.KOREA));
         OAuthMemberSignUpRequest request = new OAuthMemberSignUpRequest(null, Platform.KAKAO.getValue(),
-                platformId);
+                platformId, Nation.KOREA.getValue());
 
         memberService.signUpByOAuthMember(request);
 
@@ -66,9 +67,9 @@ public class MemberServiceTest {
     @Test
     @DisplayName("OAuth 유저 로그인 후 회원가입 시 platform과 platformId 정보로 회원이 존재하지 않으면 예외를 반환한다")
     void signUpByOAuthMemberWhenInvalidPlatformInfo() {
-        memberRepository.save(new Member("dlawotn3@naver.com", Platform.KAKAO, "1234321"));
+        memberRepository.save(new Member("dlawotn3@naver.com", Platform.KAKAO, "1234321", Nation.KOREA));
         OAuthMemberSignUpRequest request = new OAuthMemberSignUpRequest(null, Platform.KAKAO.getValue(),
-                "invalid");
+                "invalid", Nation.KOREA.getValue());
 
         assertThatThrownBy(() -> memberService.signUpByOAuthMember(request))
                 .isInstanceOf(NotFoundMemberException.class);


### PR DESCRIPTION
## 개요
- 해당 서비스는 한국, 네덜란드 두 국가에 출시할 예정이라 국가 구분이 필요하여 Nation 컬럼을 추가했습니다.

## 작업사항
- Nation Enum 및 컬럼 추가
- OAuth 회원가입 로직 수정
  - 처음 OAuth 로그인을 수행(아직 OAuth 회원가입 진행X)한 사람은 디폴트 값인 KOREA로 국가가 설정되지만 실제 OAuth 회원가입이 진행되면 회원의 국가에 맞는 값으로 변경되도록 로직을 구성했습니다. 
- Nation 컬럼 추가로 인한 테스트 코드 수정

## 주의사항
- 국가 구분을 했지만 국가에 맞는 시간대로 변경하는 로직은 아직 추가가 안됐습니다
  - 이 부분은 나중에 회의를 통해 결정해야 할 거 같습니다 
- 해당 변경사항으로 인해 OAuth 회원가입 API 명세서가 수정되었습니다
- 이메일 회원가입은 테스트용이므로 이메일 회원가입을 진행하면 무조건 KOREA로 가입되도록 수정했습니다
- 더 좋은 로직이 있다면 추천해주세요
