### PR TITLE
feat: 해당 달에 일기가 존재하는 날짜 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,8 @@ dependencies {
 	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'io.rest-assured:rest-assured'
+	testImplementation 'org.mockito:mockito-core:5.0.0'
+	testImplementation 'net.bytebuddy:byte-buddy:1.12.22'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -37,8 +37,6 @@ dependencies {
 	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'io.rest-assured:rest-assured'
-	testImplementation 'org.mockito:mockito-core:5.0.0'
-	testImplementation 'net.bytebuddy:byte-buddy:1.12.22'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/thanksd/server/controller/DiaryController.java
+++ b/src/main/java/com/thanksd/server/controller/DiaryController.java
@@ -1,25 +1,16 @@
 package com.thanksd.server.controller;
 
 import com.thanksd.server.dto.request.DiaryRequest;
-import com.thanksd.server.dto.response.DiaryAllResponse;
-import com.thanksd.server.dto.response.DiaryIdResponse;
-import com.thanksd.server.dto.response.DiaryResponse;
-import com.thanksd.server.dto.response.Response;
+import com.thanksd.server.dto.response.*;
 import com.thanksd.server.security.auth.LoginUserId;
 import com.thanksd.server.service.DiaryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
 
 @Tag(name = "Diaries", description = "일기")
 @RestController
@@ -64,6 +55,16 @@ public class DiaryController {
     @DeleteMapping("/{id}")
     public Response<Object> deleteDiary(@LoginUserId Long memberId, @PathVariable Long id) {
         DiaryIdResponse response = diaryService.deleteDiary(memberId, id);
+        return Response.ofSuccess("OK", response);
+    }
+
+    @Operation(summary = "해당 달에 일기 존재하는 날짜 조회")
+    @GetMapping("/calendar")
+    public Response<Object> findExistingDiaryDate(
+            @LoginUserId Long memberId,
+            @RequestParam("year") final int year,
+            @RequestParam("month") final int month) {
+        DiaryDateResponse response = diaryService.findExistingDiaryDate(memberId, year, month);
         return Response.ofSuccess("OK", response);
     }
 }

--- a/src/main/java/com/thanksd/server/domain/BaseTime.java
+++ b/src/main/java/com/thanksd/server/domain/BaseTime.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import javax.persistence.Column;
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
-import java.sql.Timestamp;
+import java.time.LocalDateTime;
 
 @Getter
 @MappedSuperclass
@@ -17,9 +17,9 @@ public class BaseTime {
 
     @CreatedDate
     @Column(name = "created_time", updatable = false)
-    private Timestamp createdTime;
+    private LocalDateTime createdTime;
 
     @LastModifiedDate
     @Column(name = "modified_time")
-    private Timestamp modifiedTime;
+    private LocalDateTime modifiedTime;
 }

--- a/src/main/java/com/thanksd/server/domain/Diary.java
+++ b/src/main/java/com/thanksd/server/domain/Diary.java
@@ -1,24 +1,17 @@
 package com.thanksd.server.domain;
 
 import com.thanksd.server.exception.badrequest.MemberMismatchException;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
 
 @Entity
 @Table(name = "diary")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Diary {
+public class Diary extends BaseTime {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "diary_id")

--- a/src/main/java/com/thanksd/server/dto/response/DiaryDateResponse.java
+++ b/src/main/java/com/thanksd/server/dto/response/DiaryDateResponse.java
@@ -2,7 +2,7 @@ package com.thanksd.server.dto.response;
 
 import lombok.*;
 
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.List;
 
 @Getter
@@ -10,5 +10,5 @@ import java.util.List;
 @AllArgsConstructor
 @ToString
 public class DiaryDateResponse {
-    private List<Date> dateList;
+    private List<LocalDate> dateList;
 }

--- a/src/main/java/com/thanksd/server/dto/response/DiaryDateResponse.java
+++ b/src/main/java/com/thanksd/server/dto/response/DiaryDateResponse.java
@@ -1,0 +1,14 @@
+package com.thanksd.server.dto.response;
+
+import lombok.*;
+
+import java.util.Date;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@ToString
+public class DiaryDateResponse {
+    private List<Date> dateList;
+}

--- a/src/main/java/com/thanksd/server/repository/DiaryRepository.java
+++ b/src/main/java/com/thanksd/server/repository/DiaryRepository.java
@@ -1,6 +1,12 @@
 package com.thanksd.server.repository;
 
 import com.thanksd.server.domain.Diary;
+import com.thanksd.server.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface DiaryRepository extends JpaRepository<Diary, Long> {}
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface DiaryRepository extends JpaRepository<Diary, Long> {
+    List<Diary> findByMemberAndCreatedTimeBetween(Member member, LocalDateTime start, LocalDateTime end);
+}

--- a/src/main/java/com/thanksd/server/service/DiaryService.java
+++ b/src/main/java/com/thanksd/server/service/DiaryService.java
@@ -115,11 +115,15 @@ public class DiaryService {
         LocalDateTime start = LocalDateTime.of(year, month, 1, 0, 0);
         LocalDateTime end = start.plusMonths(1);
 
-        List<Diary> diaries = diaryRepository.findByMemberAndCreatedTimeBetween(member, start, end);
-        List<LocalDate> dateList = diaries.stream()
-                .map(diary -> diary.getCreatedTime().toLocalDate())
-                .collect(Collectors.toList());
+        List<LocalDate> dateList = getDiaryDates(member, start, end);
 
         return new DiaryDateResponse(dateList);
+    }
+
+    private List<LocalDate> getDiaryDates(Member member, LocalDateTime start, LocalDateTime end) {
+        List<Diary> diaries = diaryRepository.findByMemberAndCreatedTimeBetween(member, start, end);
+        return diaries.stream()
+                .map(diary -> diary.getCreatedTime().toLocalDate())
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/thanksd/server/service/DiaryService.java
+++ b/src/main/java/com/thanksd/server/service/DiaryService.java
@@ -4,17 +4,22 @@ import com.thanksd.server.domain.Diary;
 import com.thanksd.server.domain.Member;
 import com.thanksd.server.dto.request.DiaryRequest;
 import com.thanksd.server.dto.response.DiaryAllResponse;
+import com.thanksd.server.dto.response.DiaryDateResponse;
 import com.thanksd.server.dto.response.DiaryIdResponse;
 import com.thanksd.server.dto.response.DiaryResponse;
 import com.thanksd.server.exception.notfound.NotFoundDiaryException;
 import com.thanksd.server.exception.notfound.NotFoundMemberException;
 import com.thanksd.server.repository.DiaryRepository;
 import com.thanksd.server.repository.MemberRepository;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -101,5 +106,20 @@ public class DiaryService {
         diary.validateDiaryOwner(member);
 
         return new DiaryResponse(diary.getContent(), diary.getFont(), diary.getImage());
+    }
+
+    public DiaryDateResponse findExistingDiaryDate(Long memberId, int year, int month) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(NotFoundMemberException::new);
+
+        LocalDateTime start = LocalDateTime.of(year, month, 1, 0, 0);
+        LocalDateTime end = start.plusMonths(1);
+
+        List<Diary> diaries = diaryRepository.findByMemberAndCreatedTimeBetween(member, start, end);
+        List<LocalDate> dateList = diaries.stream()
+                .map(diary -> diary.getCreatedTime().toLocalDate())
+                .collect(Collectors.toList());
+
+        return new DiaryDateResponse(dateList);
     }
 }

--- a/src/test/java/com/thanksd/server/service/DiaryServiceTest.java
+++ b/src/test/java/com/thanksd/server/service/DiaryServiceTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import java.time.LocalDate;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -134,22 +133,9 @@ class DiaryServiceTest {
     }
 
     @Test
-    @DisplayName("해당 달에 일기가 존재하는 날짜를 반환한다")
-    public void getExistingDiaryDate() {
-        DiaryRequest diaryRequest = new DiaryRequest("content", "sans", "https://s3.~~");
-        diaryService.saveDiary(diaryRequest, member.getId());
-
-        DiaryDateResponse findDiaryDate = diaryService.findExistingDiaryDate(member.getId(), LocalDate.now().getYear(),
-                LocalDate.now().getMonthValue());
-
-        assertThat(findDiaryDate.getDateList().size()).isEqualTo(1);
-    }
-
-    @Test
     @DisplayName("해당 달에 존재하는 일기가 없다면 빈 리스트를 반환한다")
     public void getExistingDiaryDateWhenNotSavedDiary() {
-        DiaryDateResponse findDiaryDate = diaryService.findExistingDiaryDate(member.getId(), LocalDate.now().getYear(),
-                LocalDate.now().getMonthValue());
+        DiaryDateResponse findDiaryDate = diaryService.findExistingDiaryDate(member.getId(), 2023, 1);
 
         assertThat(findDiaryDate.getDateList().size()).isEqualTo(0);
     }

--- a/src/test/java/com/thanksd/server/service/DiaryServiceTest.java
+++ b/src/test/java/com/thanksd/server/service/DiaryServiceTest.java
@@ -1,22 +1,25 @@
 package com.thanksd.server.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import com.thanksd.server.domain.Diary;
 import com.thanksd.server.domain.Member;
 import com.thanksd.server.dto.request.DiaryRequest;
+import com.thanksd.server.dto.response.DiaryDateResponse;
 import com.thanksd.server.dto.response.DiaryResponse;
 import com.thanksd.server.exception.badrequest.MemberMismatchException;
 import com.thanksd.server.exception.notfound.NotFoundDiaryException;
 import com.thanksd.server.repository.DiaryRepository;
 import com.thanksd.server.repository.MemberRepository;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ServiceTest
 class DiaryServiceTest {
@@ -128,5 +131,26 @@ class DiaryServiceTest {
                 .isInstanceOf(MemberMismatchException.class);
         assertThatThrownBy(() -> diaryService.deleteDiary(secondMember.getId(), diaryId))
                 .isInstanceOf(MemberMismatchException.class);
+    }
+
+    @Test
+    @DisplayName("해당 달에 일기가 존재하는 날짜를 반환한다")
+    public void getExistingDiaryDate() {
+        DiaryRequest diaryRequest = new DiaryRequest("content", "sans", "https://s3.~~");
+        diaryService.saveDiary(diaryRequest, member.getId());
+
+        DiaryDateResponse findDiary = diaryService.findExistingDiaryDate(member.getId(), LocalDate.now().getYear(),
+                LocalDate.now().getMonthValue());
+
+        assertThat(findDiary.getDateList().size()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("해당 달에 존재하는 일기가 없다면 빈 리스트를 반환한다")
+    public void getExistingDiaryDateWhenNotSavedDiary() {
+        DiaryDateResponse findDiary = diaryService.findExistingDiaryDate(member.getId(), LocalDate.now().getYear(),
+                LocalDate.now().getMonthValue());
+
+        assertThat(findDiary.getDateList().size()).isEqualTo(0);
     }
 }

--- a/src/test/java/com/thanksd/server/service/DiaryServiceTest.java
+++ b/src/test/java/com/thanksd/server/service/DiaryServiceTest.java
@@ -139,18 +139,18 @@ class DiaryServiceTest {
         DiaryRequest diaryRequest = new DiaryRequest("content", "sans", "https://s3.~~");
         diaryService.saveDiary(diaryRequest, member.getId());
 
-        DiaryDateResponse findDiary = diaryService.findExistingDiaryDate(member.getId(), LocalDate.now().getYear(),
+        DiaryDateResponse findDiaryDate = diaryService.findExistingDiaryDate(member.getId(), LocalDate.now().getYear(),
                 LocalDate.now().getMonthValue());
 
-        assertThat(findDiary.getDateList().size()).isEqualTo(1);
+        assertThat(findDiaryDate.getDateList().size()).isEqualTo(1);
     }
 
     @Test
     @DisplayName("해당 달에 존재하는 일기가 없다면 빈 리스트를 반환한다")
     public void getExistingDiaryDateWhenNotSavedDiary() {
-        DiaryDateResponse findDiary = diaryService.findExistingDiaryDate(member.getId(), LocalDate.now().getYear(),
+        DiaryDateResponse findDiaryDate = diaryService.findExistingDiaryDate(member.getId(), LocalDate.now().getYear(),
                 LocalDate.now().getMonthValue());
 
-        assertThat(findDiary.getDateList().size()).isEqualTo(0);
+        assertThat(findDiaryDate.getDateList().size()).isEqualTo(0);
     }
 }


### PR DESCRIPTION
## 개요
- ThanksD 서비스에는 일기를 편리하게 조회할 수 있는 달력이 존재합니다. 그렇기에 달력에 일기가 존재하는 날짜를 조회할 수 있도록 해당 기능을 구현했습니다.

## 작업사항
- Diary에 extends BaseTime 추가
- BaseTime 타입을 `Timestamp`에서 `LocalDateTime`로 변경
- 해당 달에 일기가 존재하는 날짜 조회 기능 로직 구현
- 관련 테스트 코드 추가 

## 주의사항
- `BaseTime` 타입을 `LocalDateTime`으로 변경했습니다
- `createdTime`은 다이어리 생성 날짜를 기준으로 설정됩니다. 그렇기에 해당 기능 관련 테스트 코드에서 year와 month를 now를 기준으로 설정하도록 했습니다
  - 이렇게 테스트 코드를 작성하면 23:59에서 x월 1일 00:00으로 넘어갈 때 ci 테스트를 수행할 경우, 일기 작성 month와 now의 month가 달라져서 ci가 실패할 가능성이 있다고 생각합니다. 하지만 이럴 가능성은 매우 희박하다고 생각하여 일단 이렇게 작성했습니다
  - 더 좋은 방법이 있다면 알려주세요
