### PR TITLE
feat: 해당 날짜에 존재하는 일기 조회 기능 구현

### DIFF
--- a/src/main/java/com/thanksd/server/controller/ControllerAdvice.java
+++ b/src/main/java/com/thanksd/server/controller/ControllerAdvice.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.Objects;
@@ -75,6 +76,14 @@ public class ControllerAdvice {
 
         return ResponseEntity.badRequest()
                 .body(new ErrorResponse(9004, "요청 파일이 올바르지 않습니다. 파일 손상 여부나 요청 형식을 확인해주세요."));
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
+        log.warn("Invalid date format! Please provide the date in the format yyyy-MM-dd. ErrMessage={}\n", e.getMessage());
+
+        return ResponseEntity.badRequest()
+                .body(new ErrorResponse(9005, "올바른 날짜 형식으로 입력해주세요."));
     }
 
     @ExceptionHandler(ThanksdException.class)

--- a/src/main/java/com/thanksd/server/controller/DiaryController.java
+++ b/src/main/java/com/thanksd/server/controller/DiaryController.java
@@ -8,9 +8,11 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.time.LocalDate;
 
 @Tag(name = "Diaries", description = "일기")
 @RestController
@@ -65,6 +67,15 @@ public class DiaryController {
             @RequestParam("year") final int year,
             @RequestParam("month") final int month) {
         DiaryDateResponse response = diaryService.findExistingDiaryDate(memberId, year, month);
+        return Response.ofSuccess("OK", response);
+    }
+
+    @Operation(summary = "해당 날짜에 존재하는 일기 조회")
+    @GetMapping("/date")
+    public Response<Object> findDiaryByDate(
+            @LoginUserId Long memberId,
+            @RequestParam("date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
+        DiaryInfoListResponse response = diaryService.findDiaryByDate(memberId, date);
         return Response.ofSuccess("OK", response);
     }
 }

--- a/src/main/java/com/thanksd/server/dto/response/DiaryInfoListResponse.java
+++ b/src/main/java/com/thanksd/server/dto/response/DiaryInfoListResponse.java
@@ -1,0 +1,13 @@
+package com.thanksd.server.dto.response;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@ToString
+public class DiaryInfoListResponse {
+    private List<DiaryInfoResponse> diaryList;
+}

--- a/src/main/java/com/thanksd/server/dto/response/DiaryInfoResponse.java
+++ b/src/main/java/com/thanksd/server/dto/response/DiaryInfoResponse.java
@@ -1,0 +1,12 @@
+package com.thanksd.server.dto.response;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@ToString
+public class DiaryInfoResponse {
+    private Long id;
+    private String image;
+}

--- a/src/main/java/com/thanksd/server/repository/DiaryRepository.java
+++ b/src/main/java/com/thanksd/server/repository/DiaryRepository.java
@@ -3,10 +3,16 @@ package com.thanksd.server.repository;
 import com.thanksd.server.domain.Diary;
 import com.thanksd.server.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
     List<Diary> findByMemberAndCreatedTimeBetween(Member member, LocalDateTime start, LocalDateTime end);
+
+    @Query("SELECT d FROM Diary d WHERE d.member = :member AND DATE(d.createdTime) = :date")
+    List<Diary> findDiariesByCreatedTime(@Param("member") Member member, @Param("date") LocalDate date);
 }

--- a/src/main/java/com/thanksd/server/service/DiaryService.java
+++ b/src/main/java/com/thanksd/server/service/DiaryService.java
@@ -3,10 +3,7 @@ package com.thanksd.server.service;
 import com.thanksd.server.domain.Diary;
 import com.thanksd.server.domain.Member;
 import com.thanksd.server.dto.request.DiaryRequest;
-import com.thanksd.server.dto.response.DiaryAllResponse;
-import com.thanksd.server.dto.response.DiaryDateResponse;
-import com.thanksd.server.dto.response.DiaryIdResponse;
-import com.thanksd.server.dto.response.DiaryResponse;
+import com.thanksd.server.dto.response.*;
 import com.thanksd.server.exception.notfound.NotFoundDiaryException;
 import com.thanksd.server.exception.notfound.NotFoundMemberException;
 import com.thanksd.server.repository.DiaryRepository;
@@ -124,6 +121,21 @@ public class DiaryService {
         List<Diary> diaries = diaryRepository.findByMemberAndCreatedTimeBetween(member, start, end);
         return diaries.stream()
                 .map(diary -> diary.getCreatedTime().toLocalDate())
+                .collect(Collectors.toList());
+    }
+
+    public DiaryInfoListResponse findDiaryByDate(Long memberId, LocalDate date) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(NotFoundMemberException::new);
+
+        List<DiaryInfoResponse> diaryInfoList = getDiaryList(member, date);
+        return new DiaryInfoListResponse(diaryInfoList);
+    }
+
+    private List<DiaryInfoResponse> getDiaryList(Member member, LocalDate date) {
+        List<Diary> diaries = diaryRepository.findDiariesByCreatedTime(member, date);
+        return diaries.stream()
+                .map(diary -> new DiaryInfoResponse(diary.getId(), diary.getImage()))
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,9 +28,9 @@ spring:
       client:
         registration:
           google:
-            client-id: test
-            client-secret: test
-            redirect-uri: test
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            redirect-uri: ${GOOGLE_REDIRECT_URI}
             scope:
               - email
 

--- a/src/test/java/com/thanksd/server/service/DiaryServiceTest.java
+++ b/src/test/java/com/thanksd/server/service/DiaryServiceTest.java
@@ -4,6 +4,7 @@ import com.thanksd.server.domain.Diary;
 import com.thanksd.server.domain.Member;
 import com.thanksd.server.dto.request.DiaryRequest;
 import com.thanksd.server.dto.response.DiaryDateResponse;
+import com.thanksd.server.dto.response.DiaryInfoListResponse;
 import com.thanksd.server.dto.response.DiaryResponse;
 import com.thanksd.server.exception.badrequest.MemberMismatchException;
 import com.thanksd.server.exception.notfound.NotFoundDiaryException;
@@ -14,6 +15,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -138,5 +140,13 @@ class DiaryServiceTest {
         DiaryDateResponse findDiaryDate = diaryService.findExistingDiaryDate(member.getId(), 2023, 1);
 
         assertThat(findDiaryDate.getDateList().size()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("해당 날짜에 존재하는 일기가 없다면 빈 리스트를 반환한다")
+    public void findDiaryByDate() {
+        DiaryInfoListResponse findDiaryInfoList = diaryService.findDiaryByDate(member.getId(), LocalDate.ofEpochDay(2023-01-12));
+
+        assertThat(findDiaryInfoList.getDiaryList().size()).isEqualTo(0);
     }
 }


### PR DESCRIPTION
## 개요
- 해당 날짜에 존재하는 일기의 id와 이미지 url을 리스트로 반환하는 기능을 구현했습니다

## 작업사항
- 해당 날짜에 존재하는 일기 조회 기능 로직 구현
- 잘못된 date 파람에 대해 예외 처리 추가
- 관련 테스트 코드 추가
- google oauth 환경변수 수정

## 주의사항
- 요청을 보낼 때 아래와 같이 date에 yyyy-mm-dd 형식으로 보내야 합니다
  - <img width="400" alt="image" src="https://github.com/Konkuk-ThanksD/Server/assets/69844138/e64c91be-9b60-48b7-8b28-2d273a90f3d8">
 
- 해당 기능도 특정 날짜 기준으로 조회하는 기능이라 빈 리스트를 반환하는 테스트코드만 작성했습니다