### PR TITLE
feat: 일기 삭제 시, s3에 업로드 되어 있는 이미지도 같이 삭제 기능 추가

### DIFF
--- a/src/main/java/com/thanksd/server/controller/DiaryController.java
+++ b/src/main/java/com/thanksd/server/controller/DiaryController.java
@@ -60,6 +60,7 @@ public class DiaryController {
     @DeleteMapping("/{id}")
     public Response<Object> deleteDiary(@LoginUserId Long memberId, @PathVariable Long id) {
 
+        presignedUrlService.deleteByPath(id);
         DiaryIdResponse response = diaryService.deleteDiary(memberId, id);
         return Response.ofSuccess("OK", response);
     }

--- a/src/main/java/com/thanksd/server/controller/DiaryController.java
+++ b/src/main/java/com/thanksd/server/controller/DiaryController.java
@@ -23,7 +23,6 @@ public class DiaryController {
 
     private final DiaryService diaryService;
     private final PreSignedUrlService presignedUrlService;
-    private final String prefixImagePath = "images";
 
     @Operation(summary = "모든 일기 불러오기")
     @GetMapping
@@ -69,7 +68,7 @@ public class DiaryController {
     @PostMapping("/presigned")
     public Response<Object> preSignedUrl(@LoginUserId Long memberId,@RequestParam("image") String imageName){
 
-        PreSignedUrlResponse response = presignedUrlService.getPreSignedUrl(prefixImagePath,imageName,memberId);
+        PreSignedUrlResponse response = presignedUrlService.getPreSignedUrl(imageName,memberId);
         return Response.ofSuccess("OK", response);
     }
 

--- a/src/main/java/com/thanksd/server/controller/DiaryController.java
+++ b/src/main/java/com/thanksd/server/controller/DiaryController.java
@@ -22,7 +22,7 @@ import javax.validation.Valid;
 public class DiaryController {
 
     private final DiaryService diaryService;
-    private final PreSignedUrlService presignedUrlService;
+    private final PreSignedUrlService preSignedUrlService;
 
     @Operation(summary = "모든 일기 불러오기")
     @GetMapping
@@ -43,6 +43,7 @@ public class DiaryController {
     @Operation(summary = "특정 일기 조회")
     @GetMapping("/{id}")
     public Response<Object> findDiary(@LoginUserId Long memberId, @PathVariable Long id) {
+
         DiaryResponse response = diaryService.findOne(memberId, id);
         return Response.ofSuccess("OK", response);
     }
@@ -51,6 +52,10 @@ public class DiaryController {
     @PutMapping("/{id}")
     public Response<Object> updateDiary(@LoginUserId Long memberId, @PathVariable Long id,
                                         @RequestBody DiaryUpdateRequest diaryUpdateRequest) {
+
+        if(!(diaryUpdateRequest.getImage().isBlank())){
+            preSignedUrlService.deleteByPath(memberId,id);
+        }
         DiaryResponse response = diaryService.updateDiary(diaryUpdateRequest, memberId, id);
         return Response.ofSuccess("OK", response);
     }
@@ -59,7 +64,7 @@ public class DiaryController {
     @DeleteMapping("/{id}")
     public Response<Object> deleteDiary(@LoginUserId Long memberId, @PathVariable Long id) {
 
-        presignedUrlService.deleteByPath(id);
+        preSignedUrlService.deleteByPath(memberId,id);
         DiaryIdResponse response = diaryService.deleteDiary(memberId, id);
         return Response.ofSuccess("OK", response);
     }
@@ -68,7 +73,7 @@ public class DiaryController {
     @PostMapping("/presigned")
     public Response<Object> preSignedUrl(@LoginUserId Long memberId,@RequestParam("image") String imageName){
 
-        PreSignedUrlResponse response = presignedUrlService.getPreSignedUrl(imageName,memberId);
+        PreSignedUrlResponse response = preSignedUrlService.getPreSignedUrl(imageName,memberId);
         return Response.ofSuccess("OK", response);
     }
 

--- a/src/main/java/com/thanksd/server/domain/Diary.java
+++ b/src/main/java/com/thanksd/server/domain/Diary.java
@@ -71,7 +71,8 @@ public class Diary extends BaseTime {
     public void update(String content, String font, String image) {
         this.content = content;
         this.font = font;
-        setImage(image);
+        if(this.image!= image)
+            setImage(image);
     }
 
     public void disConnectMember(){

--- a/src/main/java/com/thanksd/server/service/DiaryService.java
+++ b/src/main/java/com/thanksd/server/service/DiaryService.java
@@ -50,8 +50,8 @@ public class DiaryService {
 
         Diary findDiary = diaryRepository.findById(diaryId)
                 .orElseThrow(NotFoundDiaryException::new);
-        findDiary.validateDiaryOwner(member);
 
+        findDiary.validateDiaryOwner(member);
         findDiary.update(
                 validateData(findDiary.getContent(), diaryUpdateRequest.getContent()),
                 validateData(findDiary.getFont(), diaryUpdateRequest.getFont()),
@@ -76,8 +76,8 @@ public class DiaryService {
 
         Diary findDiary = diaryRepository.findById(diaryId)
                 .orElseThrow(NotFoundDiaryException::new);
-        findDiary.validateDiaryOwner(member);
 
+        findDiary.validateDiaryOwner(member);
         findDiary.disConnectMember();
         diaryRepository.delete(findDiary);
 

--- a/src/main/java/com/thanksd/server/service/DiaryService.java
+++ b/src/main/java/com/thanksd/server/service/DiaryService.java
@@ -78,8 +78,6 @@ public class DiaryService {
                 .orElseThrow(NotFoundDiaryException::new);
         findDiary.validateDiaryOwner(member);
 
-//        preSignedUrlService.deleteByPath(findDiary.getImage());
-
         findDiary.disConnectMember();
         diaryRepository.delete(findDiary);
 

--- a/src/main/java/com/thanksd/server/service/PreSignedUrlService.java
+++ b/src/main/java/com/thanksd/server/service/PreSignedUrlService.java
@@ -36,8 +36,7 @@ public class PreSignedUrlService {
 
     public PreSignedUrlResponse getPreSignedUrl(String imageName, Long memberId) {
 
-        GeneratePresignedUrlRequest generatePresignedUrlRequest = getGeneratePresignedUrlRequest(
-                prefixImagePath, imageName, memberId);
+        GeneratePresignedUrlRequest generatePresignedUrlRequest = getGeneratePreSignedUrlRequest(imageName, memberId);
 
         return new PreSignedUrlResponse(generatePreSignedUrl(generatePresignedUrlRequest));
     }
@@ -53,20 +52,18 @@ public class PreSignedUrlService {
         return preSignedUrl;
     }
 
-    private GeneratePresignedUrlRequest getGeneratePresignedUrlRequest(String prefixImagePath, String imageName,
-                                                                       Long memberId) {
+    private GeneratePresignedUrlRequest getGeneratePreSignedUrlRequest(String imageName, Long memberId) {
         savedImageName = uniqueImageName(imageName, memberId);
 
         String savedImagePath = savedImageName;
         if (!prefixImagePath.isBlank()) {
             savedImagePath = prefixImagePath + "/" + savedImageName;
         }
-        GeneratePresignedUrlRequest generatePresignedUrlRequest = getGeneratePreSignedUrlRequest(bucket,
-                savedImagePath);
+        GeneratePresignedUrlRequest generatePresignedUrlRequest = getPreSignedUrlRequest(bucket, savedImagePath);
         return generatePresignedUrlRequest;
     }
 
-    private GeneratePresignedUrlRequest getGeneratePreSignedUrlRequest(String bucket, String imageName) {
+    private GeneratePresignedUrlRequest getPreSignedUrlRequest(String bucket, String imageName) {
         GeneratePresignedUrlRequest generatePresignedUrlRequest =
                 new GeneratePresignedUrlRequest(bucket, imageName)
                         .withMethod(HttpMethod.PUT)

--- a/src/main/java/com/thanksd/server/service/PreSignedUrlService.java
+++ b/src/main/java/com/thanksd/server/service/PreSignedUrlService.java
@@ -23,13 +23,14 @@ public class PreSignedUrlService {
     private final AmazonS3Client amazonS3Client;
     private final DiaryRepository diaryRepository;
     private String savedImageName;
+    private final String prefixImagePath = "images";
 
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
     @Value("${cloud.aws.region.static}")
     private String location;
 
-    public PreSignedUrlResponse getPreSignedUrl(String prefixImagePath, String imageName, Long memberId) {
+    public PreSignedUrlResponse getPreSignedUrl(String imageName, Long memberId) {
 
         GeneratePresignedUrlRequest generatePresignedUrlRequest = getGeneratePresignedUrlRequest(
                 prefixImagePath, imageName, memberId);

--- a/src/test/java/com/thanksd/server/service/DiaryServiceTest.java
+++ b/src/test/java/com/thanksd/server/service/DiaryServiceTest.java
@@ -116,6 +116,24 @@ class DiaryServiceTest {
     }
 
     @Test
+    @DisplayName("업데이트 시, 공백값이 들어온 경우 기존 값을 유지한다.")
+    public void notChangeValueWhenBlankRequest() {
+        //given
+        DiaryRequest oldDiaryRequest = new DiaryRequest("oldContent", "sans",imageUrl);
+        DiaryUpdateRequest newDiaryRequest = new DiaryUpdateRequest("", "", "");
+
+        //when
+        Long diaryId = diaryService.saveDiary(oldDiaryRequest,member.getId()).getId();
+        diaryService.updateDiary(newDiaryRequest, member.getId(), diaryId);
+
+        //then
+        DiaryResponse findDiaryResponse = diaryService.findOne(member.getId(), diaryId);
+        assertEquals(oldDiaryRequest.getContent(), findDiaryResponse.getContent(), "기존 일기 내용이 같아야 한다.");
+        assertEquals(oldDiaryRequest.getFont(), findDiaryResponse.getFont(), "기존 일기 폰트가 같아야 한다.");
+        assertEquals("images/1/cc4342b5-126f-4c73-a0b7-f70ad0a58ea6_test.jpg", findDiaryResponse.getImage(), "기존 일기 이미지가 같아야 한다.");
+    }
+
+    @Test
     @DisplayName("일기는 작성자만 접근가능하다.")
     public void accessDiary() {
         //given


### PR DESCRIPTION
## 개요
- 이전 pr에서 기능적인 부분은 완성했지만 test코드가 제대로 수행되지 않아서 s3에서 이미지 지우는 메서드 호출 부분을 controller로 바꾸고 test는 diary객체 자체에 대해서만 테스트를 진행했습니다.

## 작업사항
- s3에 업로드 된 이미지 삭제 기능 추가
- 일기 삭제 요청 시, s3에도 이미지 삭제 요청하도록 작성

## 주의사항
- deleteByPath 메서드의 파라미터를 path자체를 전달하는 것에서 일기의 id를 전달해 메서드 내부에서 path를 찾도록 변경했습니다.
- Service에서 Controller로 호출 시점을 변경하여 test엔 문제 없도록 작성했습니다.
