### PR TITLE
fix: BaseTime 오류 해결 및 날짜별 일기 조회 로직 수정

### DIFF
--- a/src/main/java/com/thanksd/server/domain/BaseTime.java
+++ b/src/main/java/com/thanksd/server/domain/BaseTime.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import javax.persistence.Column;
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
-import java.time.LocalDateTime;
+import java.sql.Timestamp;
 
 @Getter
 @MappedSuperclass
@@ -17,9 +17,9 @@ public class BaseTime {
 
     @CreatedDate
     @Column(name = "created_time", updatable = false)
-    private LocalDateTime createdTime;
+    private Timestamp createdTime;
 
     @LastModifiedDate
     @Column(name = "modified_time")
-    private LocalDateTime modifiedTime;
+    private Timestamp modifiedTime;
 }

--- a/src/main/java/com/thanksd/server/repository/DiaryRepository.java
+++ b/src/main/java/com/thanksd/server/repository/DiaryRepository.java
@@ -6,13 +6,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.sql.Timestamp;
 import java.util.List;
 
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
-    List<Diary> findByMemberAndCreatedTimeBetween(Member member, LocalDateTime start, LocalDateTime end);
+    List<Diary> findByMemberAndCreatedTimeBetween(Member member, Timestamp createdTime, Timestamp createdTime2);
 
     @Query("SELECT d FROM Diary d WHERE d.member = :member AND DATE(d.createdTime) = :date")
-    List<Diary> findDiariesByCreatedTime(@Param("member") Member member, @Param("date") LocalDate date);
+    List<Diary> findDiariesByCreatedTime(@Param("member") Member member, @Param("date") Timestamp date);
 }


### PR DESCRIPTION
## 개요
- `LocalDateTime`을 mysql에서 인식하지 못하는 문제로 `createdTime`, `modifiedTime` 타입을 `Timestamp`로 변경했습니다 

## 작업사항
- `createdTime`, `modifiedTime` 타입 변경

## 주의사항
- 해당 PR은 바로 머지합니다