### PR TITLE
fix: 일기가 존재하는 날짜 반환 기능에서 리스트 중복 제거 로직 추가

### DIFF
--- a/src/main/java/com/thanksd/server/service/DiaryService.java
+++ b/src/main/java/com/thanksd/server/service/DiaryService.java
@@ -123,9 +123,7 @@ public class DiaryService {
         Timestamp start = Timestamp.valueOf(startDate);
         Timestamp end = Timestamp.valueOf(endDate);
 
-        List<LocalDate> dateList = getDiaryDates(member, start, end).stream()
-                .distinct()
-                .collect(Collectors.toList());
+        List<LocalDate> dateList = getDiaryDates(member, start, end);
 
         return new DiaryDateResponse(dateList);
     }
@@ -142,6 +140,7 @@ public class DiaryService {
         List<Diary> diaries = diaryRepository.findByMemberAndCreatedTimeBetween(member, start, end);
         return diaries.stream()
                 .map(diary -> diary.getCreatedTime().toLocalDateTime().toLocalDate())
+                .distinct()
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/thanksd/server/service/DiaryService.java
+++ b/src/main/java/com/thanksd/server/service/DiaryService.java
@@ -4,18 +4,16 @@ import com.thanksd.server.domain.Diary;
 import com.thanksd.server.domain.Member;
 import com.thanksd.server.dto.request.DiaryRequest;
 import com.thanksd.server.dto.request.DiaryUpdateRequest;
-import com.thanksd.server.dto.response.DiaryAllResponse;
-import com.thanksd.server.dto.response.DiaryDateResponse;
-import com.thanksd.server.dto.response.DiaryIdResponse;
-import com.thanksd.server.dto.response.DiaryInfoListResponse;
-import com.thanksd.server.dto.response.DiaryInfoResponse;
-import com.thanksd.server.dto.response.DiaryResponse;
-import com.thanksd.server.dto.response.DiaryWeekCountResponse;
+import com.thanksd.server.dto.response.*;
 import com.thanksd.server.exception.badrequest.InvalidDateException;
 import com.thanksd.server.exception.notfound.NotFoundDiaryException;
 import com.thanksd.server.exception.notfound.NotFoundMemberException;
 import com.thanksd.server.repository.DiaryRepository;
 import com.thanksd.server.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import java.sql.Timestamp;
 import java.time.DateTimeException;
 import java.time.DayOfWeek;
@@ -26,9 +24,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional(readOnly = true)
@@ -128,7 +123,9 @@ public class DiaryService {
         Timestamp start = Timestamp.valueOf(startDate);
         Timestamp end = Timestamp.valueOf(endDate);
 
-        List<LocalDate> dateList = getDiaryDates(member, start, end);
+        List<LocalDate> dateList = getDiaryDates(member, start, end).stream()
+                .distinct()
+                .collect(Collectors.toList());
 
         return new DiaryDateResponse(dateList);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,7 +36,7 @@ spring:
 
 security.jwt.token:
   secret-key: testtesttesttesttesttesttesttesttestttttest
-  expire-length: 1800000
+  expire-length: 604800000
 
 springdoc:
   default-consumes-media-type: application/json

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,9 +30,6 @@ spring:
             redirect-uri: ${GOOGLE_REDIRECT_URI}
             scope:
               - email
-  config:
-    activate:
-      on-profile:
 
 security.jwt.token:
   secret-key: testtesttesttesttesttesttesttesttestttttest


### PR DESCRIPTION
## 개요
- 특정 달에서 일기가 존재하는 날짜들을 리스트로 반환하는 기존 로직에서는 같은 날에 일기를 2개 이상 작성하면 같은 날짜가 중복해서 반환됐습니다. 그럴 필요가 없기 때문에 같은 날짜가 중복해서 들어가지 않도록 로직을 추가했습니다.

## 작업사항
- `stream`을 통해 날짜 반환 리스트에서 중복 제거 로직 추가

## 주의사항
- 기능이 제대로 동작하는지 다시 한 번 확인해주세요
