### PR TITLE
feat: 일기 조회 로직 이미지 자체를 전달하도록 변경

### DIFF
--- a/src/main/java/com/thanksd/server/controller/DiaryController.java
+++ b/src/main/java/com/thanksd/server/controller/DiaryController.java
@@ -20,6 +20,7 @@ import java.time.LocalDate;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -58,10 +59,8 @@ public class DiaryController {
 
     @Operation(summary = "특정 일기 조회")
     @GetMapping("/{id}")
-    public Response<Object> findDiary(@LoginUserId Long memberId, @PathVariable Long id) {
-
-        DiaryResponse response = diaryService.findOne(memberId, id);
-        return Response.ofSuccess("OK", response);
+    public ResponseEntity<byte[]> findDiary(@LoginUserId Long memberId, @PathVariable Long id) {
+        return preSignedUrlService.getDiaryImage(memberId, id);
     }
 
     @Operation(summary = "특정 일기 수정")

--- a/src/main/java/com/thanksd/server/dto/response/DiaryAllResponse.java
+++ b/src/main/java/com/thanksd/server/dto/response/DiaryAllResponse.java
@@ -12,5 +12,5 @@ import lombok.ToString;
 @AllArgsConstructor
 @ToString
 public class DiaryAllResponse {
-    private List<DiaryResponse> diaries;
+    private List<DiaryIdResponse> diaries;
 }

--- a/src/main/java/com/thanksd/server/service/DiaryService.java
+++ b/src/main/java/com/thanksd/server/service/DiaryService.java
@@ -88,15 +88,15 @@ public class DiaryService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);
         List<Diary> diaries = member.getDiaries();
-        return new DiaryAllResponse(getDiaryResponseList(diaries));
+        return new DiaryAllResponse(getDiaryIdResponseList(diaries));
     }
 
-    private List<DiaryResponse> getDiaryResponseList(List<Diary> diaries) {
-        List<DiaryResponse> diaryResponseList = new ArrayList<>();
+    private List<DiaryIdResponse> getDiaryIdResponseList(List<Diary> diaries) {
+        List<DiaryIdResponse> diaryIdResponses = new ArrayList<>();
         for (Diary diary : diaries) {
-            diaryResponseList.add(new DiaryResponse(diary.getImage()));
+            diaryIdResponses.add(new DiaryIdResponse(diary.getId()));
         }
-        return diaryResponseList;
+        return diaryIdResponses;
     }
 
     public Diary findOne(Long memberId, Long diaryId) {

--- a/src/main/java/com/thanksd/server/service/DiaryService.java
+++ b/src/main/java/com/thanksd/server/service/DiaryService.java
@@ -99,7 +99,7 @@ public class DiaryService {
         return diaryResponseList;
     }
 
-    public DiaryResponse findOne(Long memberId, Long diaryId) {
+    public Diary findOne(Long memberId, Long diaryId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);
 
@@ -107,7 +107,7 @@ public class DiaryService {
                 .orElseThrow(NotFoundDiaryException::new);
         diary.validateDiaryOwner(member);
 
-        return new DiaryResponse(diary.getImage());
+        return diary;
     }
 
     public DiaryDateResponse findExistingDiaryDate(Long memberId, int year, int month) {

--- a/src/test/java/com/thanksd/server/service/DiaryServiceTest.java
+++ b/src/test/java/com/thanksd/server/service/DiaryServiceTest.java
@@ -11,8 +11,8 @@ import com.thanksd.server.domain.Member;
 import com.thanksd.server.dto.request.DiaryRequest;
 import com.thanksd.server.dto.request.DiaryUpdateRequest;
 import com.thanksd.server.dto.response.DiaryDateResponse;
+import com.thanksd.server.dto.response.DiaryIdResponse;
 import com.thanksd.server.dto.response.DiaryInfoListResponse;
-import com.thanksd.server.dto.response.DiaryResponse;
 import com.thanksd.server.dto.response.DiaryWeekCountResponse;
 import com.thanksd.server.exception.badrequest.InvalidDateException;
 import com.thanksd.server.exception.badrequest.MemberMismatchException;
@@ -65,7 +65,7 @@ class DiaryServiceTest {
         //then
         Diary findDiary = diaryRepository.findById(diaryId)
                 .orElseThrow(NotFoundDiaryException::new);
-        List<DiaryResponse> diaries = diaryService.findMemberDiaries(member.getId()).getDiaries();
+        List<DiaryIdResponse> diaries = diaryService.findMemberDiaries(member.getId()).getDiaries();
 
         assertThat(diaries.size()).isEqualTo(1);
         assertEquals("images/1/cc4342b5-126f-4c73-a0b7-f70ad0a58ea6_test.jpg", findDiary.getImage(),
@@ -99,11 +99,11 @@ class DiaryServiceTest {
         Long diaryId = diaryService.saveDiary(diaryRequest, member.getId()).getId();
 
         //then
-        List<DiaryResponse> diaries = diaryService.findMemberDiaries(member.getId()).getDiaries();
+        List<DiaryIdResponse> diaries = diaryService.findMemberDiaries(member.getId()).getDiaries();
         assertThat(diaries.size()).isEqualTo(1);
 
         diaryService.deleteDiary(member.getId(), diaryId);
-        List<DiaryResponse> deleteDiaries = diaryService.findMemberDiaries(member.getId()).getDiaries();
+        List<DiaryIdResponse> deleteDiaries = diaryService.findMemberDiaries(member.getId()).getDiaries();
         assertThat(deleteDiaries.size()).isEqualTo(0);
     }
 

--- a/src/test/java/com/thanksd/server/service/DiaryServiceTest.java
+++ b/src/test/java/com/thanksd/server/service/DiaryServiceTest.java
@@ -84,7 +84,7 @@ class DiaryServiceTest {
         diaryService.updateDiary(newDiaryRequest, member.getId(), diaryId);
 
         //then
-        DiaryResponse findDiaryResponse = diaryService.findOne(member.getId(), diaryId);
+        Diary findDiaryResponse = diaryService.findOne(member.getId(), diaryId);
         assertEquals("images/1/cc4342b5-126f-4c73-a0b7-f70ad0a58ea6_test.jpg", findDiaryResponse.getImage(),
                 "수정된 일기 이미지가 같아야 한다.");
     }
@@ -134,7 +134,7 @@ class DiaryServiceTest {
         diaryService.updateDiary(newDiaryRequest, member.getId(), diaryId);
 
         //then
-        DiaryResponse findDiaryResponse = diaryService.findOne(member.getId(), diaryId);
+        Diary findDiaryResponse = diaryService.findOne(member.getId(), diaryId);
         assertEquals("images/1/cc4342b5-126f-4c73-a0b7-f70ad0a58ea6_test.jpg", findDiaryResponse.getImage(),
                 "기존 일기 이미지가 같아야 한다.");
     }


### PR DESCRIPTION
## 개요
- 일기 조회 로직 이미지 자체를 전달하도록 변경

## 작업사항
- DiaryService의 findOne 메서드를 Response 반환에서 Diary자체 반환으로 변경했습니다.
- PresignedUrlService에서 S3 버킷의 이미지 자체를 가져오는 메서드 추가했습니다.
- 일기 조회 api를 이미지 url전달에서 이미지 자체를 받아오는 방식으로 수정하였습니다.
- 일기 전체 조회 api는 이미지 Url에서 일기 id를 받아오도록 수정했습니다.

## 주의사항
- api 테스트 결과 사진은 잘 받아와지는 것 확인했습니다.
