### PR TITLE
fix: presignedUrl 요청 메서드 POST -> GET으로 수정

### DIFF
--- a/src/main/java/com/thanksd/server/controller/DiaryController.java
+++ b/src/main/java/com/thanksd/server/controller/DiaryController.java
@@ -85,7 +85,7 @@ public class DiaryController {
     }
 
     @Operation(summary = "이미지 업로드를 위한 presigned url 요청")
-    @PostMapping("/presigned")
+    @GetMapping("/presigned")
     public Response<Object> preSignedUrl(@LoginUserId Long memberId, @RequestParam("image") String imageName) {
 
         PreSignedUrlResponse response = preSignedUrlService.getPreSignedUrl(imageName, memberId);


### PR DESCRIPTION
## 개요
- presignedUrl 을 받는 자체는 GET 메서드로 요청 받고 추후 url로 POST요청을 보내는 것이므로 저희 서버 presignedUrl 요청 메서드 를 POST -> GET으로 수정했습니다.

## 작업사항
- presignedUrl 요청 메서드 POST -> GET으로 수정

## 주의사항
- notion api문서에 api 수정했습니다.
